### PR TITLE
data: add unit test for intra-batch shuffling

### DIFF
--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -184,18 +184,6 @@ TEST(DatasetTest, IntraBatchShuffling) {
     slots.at(size).emplace_back(index);
   }
 
-  // Expects dataset and slots are not equal.
-  // Since, dataset is shuffled and slots are not.
-  for (std::size_t size = 0; size < counts.size(); ++size) {
-    const auto count = counts.at(size);
-    if (0 < count) {
-      const auto &dataset_vector = dataset.at(size);
-      const auto &current_vector = slots.at(size);
-      EXPECT_FALSE(std::equal(dataset_vector.begin(), dataset_vector.end(),
-                              current_vector.begin()));
-    }
-  }
-
   thread_local auto generator = std::ranlux48();
 
 // clang-format off

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -110,9 +110,9 @@ TEST(DatasetTest, IntraBatchShuffling) {
   // * Last, we check if the slots and dataset vectors are equal. 
 
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
-  thread_local auto generator = std::ranlux48();
   auto items = std::map<uint16_t, std::size_t>();
   uint16_t epoch = 0;
+
   for (uint16_t size = 1; size <= 1 << 12; ++size) {
     items.emplace(size, static_cast<std::size_t>(std::rand() % (1 << 15)));
   }
@@ -195,6 +195,9 @@ TEST(DatasetTest, IntraBatchShuffling) {
                               current_vector.begin()));
     }
   }
+
+  thread_local auto generator = std::ranlux48();
+
 // clang-format off
   #pragma omp parallel for
   // clang-format on

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -99,8 +99,8 @@ TEST(DatasetTest, Constructor) {
   EXPECT_TRUE(dataset.empty());
 }
 
-TEST(DatasetTest, IntraShuffle) {
-  // Test case for IntraShuffle
+TEST(DatasetTest, IntraBatchShuffling) {
+  // Test case for IntraBatchShuffling
   //
   // NOTE:
   //

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "flatflow/data/dataset.h"
+
 #include <cstdlib>
 #include <ctime>
 #include <map>
@@ -21,7 +23,6 @@
 #include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
 
-#include "flatflow/data/dataset.h"
 #include "flatflow/data/dataset_test.h"
 
 namespace {

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -99,6 +99,15 @@ TEST(DatasetTest, Constructor) {
 }
 
 TEST(DatasetTest, IntraShuffle) {
+  // Test case for IntraShuffle
+  //
+  // NOTE:
+  //
+  // * We first check if the dataset vectors are sorted.
+  // * After shuffling, we check if dataset vectors are not sorted.
+  // * Then using the same input vector, we shuffle the slots.
+  // * Last, we check if the slots and dataset vectors are equal. 
+
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
   thread_local auto generator = std::ranlux48();
   auto items = std::map<uint16_t, std::size_t>();
@@ -185,7 +194,9 @@ TEST(DatasetTest, IntraShuffle) {
                               current_vector.begin()));
     }
   }
-
+// clang-format off
+  #pragma omp parallel for
+  // clang-format on
   for (auto &item : slots) {
     generator.seed(static_cast<uint_fast64_t>(0UL + epoch));
     std::shuffle(item.begin(), item.end(), generator);

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "flatflow/data/dataset.h"
+
 
 #include <cstdlib>
 #include <ctime>
@@ -21,7 +21,9 @@
 
 #include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
+#include <absl/container/inlined_vector.h>
 
+#include "flatflow/data/dataset.h"
 #include "flatflow/data/dataset_test.h"
 
 namespace {
@@ -49,6 +51,14 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
   }
 
   inline bool empty() const noexcept { return recyclebin.empty(); }
+
+  inline void intra_shuffle(auto epoch){
+    on_epoch_begin(epoch);
+  }
+
+  inline std::vector<uint64_t> access_vector(uint16_t size) const noexcept{
+    return items.at(size);
+  }
 };
 
 TEST(DatasetTest, Constructor) {
@@ -90,6 +100,93 @@ TEST(DatasetTest, Constructor) {
     }
   }
   EXPECT_TRUE(dataset.empty());
+}
+
+TEST(DatasetTest, IntraShuffle) {
+  std::srand(static_cast<unsigned int>(std::time(nullptr)));
+  thread_local auto generator = std::ranlux48();
+  auto items = std::map<uint16_t, std::size_t>();
+  for (uint16_t size = 1; size <= 1 << 12; ++size) {
+    items.emplace(size, static_cast<std::size_t>(std::rand() % (1 << 15)));
+  }
+
+  auto sizes = std::vector<uint16_t>();
+  for (const auto item : items) {
+    const auto size = item.first;
+    auto count = item.second;
+    for (; 0 < count; --count) {
+      sizes.push_back(size);
+    }
+  }
+  sizes.shrink_to_fit();
+
+  auto builder = flatbuffers::FlatBufferBuilder64();
+  auto sizes__ = builder.CreateVector64(sizes);
+  auto offset = CreateSizes(builder, sizes__);
+  builder.Finish(offset);
+  auto sizes_ = GetSizes(builder.GetBufferPointer());
+  auto dataset = DatasetTest(sizes_->sizes(), 0UL);
+
+  for (const auto& item: items){
+    const auto& size = item.first;
+    EXPECT_TRUE(dataset.is_sorted(size));
+  }
+  // call on_epoch_begin for shuffle.
+  dataset.intra_shuffle(0); 
+  for (const auto& item: items){
+    const auto& size = item.first;
+    EXPECT_FALSE(dataset.is_sorted(size));
+  }
+  constexpr auto kIndexSlotSpace =
+    static_cast<std::size_t>(1 << std::numeric_limits<uint16_t>::digits);
+  auto counts =
+    absl::InlinedVector<uint64_t, kIndexSlotSpace>(kIndexSlotSpace, 0);
+
+  // clang-format off
+  #pragma omp unroll partial
+  // clang-format on
+  for (uint64_t index = 0; index < sizes.size(); ++index) {
+    const auto size = static_cast<std::size_t>(sizes[index]);
+    ++counts.at(size);
+  }
+
+  auto slots = absl::InlinedVector<std::vector<uint64_t>, kIndexSlotSpace>(
+      kIndexSlotSpace);
+
+  // clang-format off
+  #pragma omp parallel for
+  // clang-format on
+  for (std::size_t size = 0; size < counts.size(); ++size) {
+    const auto count = counts.at(size);
+    if (0 < count) {
+      slots.at(size).reserve(static_cast<std::size_t>(count));
+    }
+  }
+
+  // clang-format off
+  #pragma omp unroll partial
+  // clang-format on
+  for (uint64_t index = 0; index < sizes.size(); ++index) {
+    const auto size = static_cast<std::size_t>(sizes[index]);
+    slots.at(size).emplace_back(index);
+  }
+
+  //clang-format off
+  #pragma omp parallel for
+  // clang-format on
+  for (auto &item : slots) {
+    generator.seed(static_cast<uint_fast64_t>(0UL + 0));
+    std::shuffle(item.begin(), item.end(), generator);
+  }
+
+  for (std::size_t size = 0; size < counts.size(); ++size) {
+    const auto count = counts.at(size);
+    if (0 < count) {
+      const auto& dataset_vector = dataset.access_vector(size);
+      const auto& current_vector = slots.at(size);
+      EXPECT_TRUE(std::equal(dataset_vector.begin(),dataset_vector.end(),current_vector.begin()));
+    }
+  }
 }
 
 }  // namespace

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -51,9 +51,9 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
 
   inline bool empty() const noexcept { return recyclebin.empty(); }
 
-  inline void epoch_begin(uint64_t epoch) { on_epoch_begin(epoch); }
+  inline void shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
  
-  inline const std::vector<uint64_t>& at(uint16_t size) const noexcept {
+  inline const std::vector<uint64_t> &at(uint16_t size) const noexcept {
     return items.at(size);
   }
 };
@@ -100,15 +100,6 @@ TEST(DatasetTest, Constructor) {
 }
 
 TEST(DatasetTest, IntraBatchShuffling) {
-  // Test case for Intra-BatchShuffling
-  //
-  // NOTE:
-  //
-  // * We first check if the dataset vectors are sorted.
-  // * After shuffling, we check if dataset vectors are not sorted.
-  // * Then using the same input vector, we shuffle the slots.
-  // * Last, we check if the slots and dataset vectors are equal. 
-
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
   auto items = std::map<uint16_t, std::size_t>();
   uint16_t epoch = 0;
@@ -136,7 +127,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   auto dataset = DatasetTest(sizes_->sizes(), 0UL);
 
   // call on_epoch_begin for shuffle.
-  dataset.epoch_begin(epoch);
+  dataset.shuffle(epoch);
 
   constexpr auto kIndexSlotSpace =
       static_cast<std::size_t>(1 << std::numeric_limits<uint16_t>::digits);

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -50,9 +50,9 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
 
   inline bool empty() const noexcept { return recyclebin.empty(); }
 
-  inline void intra_shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
+  inline void on_epoch_begin(uint64_t epoch) { on_epoch_begin(epoch); }
 
-  inline std::vector<uint64_t> access_vector(uint16_t size) const noexcept {
+  inline std::vector<uint64_t> at(uint16_t size) const noexcept {
     return items.at(size);
   }
 };
@@ -141,7 +141,7 @@ TEST(DatasetTest, IntraShuffle) {
   }
 
   // call on_epoch_begin for shuffle.
-  dataset.intra_shuffle(epoch);
+  dataset.on_epoch_begin(epoch);
 
   // Expects all vectors are not sorted.
   for (const auto &item : items) {
@@ -188,7 +188,7 @@ TEST(DatasetTest, IntraShuffle) {
   for (std::size_t size = 0; size < counts.size(); ++size) {
     const auto count = counts.at(size);
     if (0 < count) {
-      const auto &dataset_vector = dataset.access_vector(size);
+      const auto &dataset_vector = dataset.at(size);
       const auto &current_vector = slots.at(size);
       EXPECT_FALSE(std::equal(dataset_vector.begin(), dataset_vector.end(),
                               current_vector.begin()));

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -112,7 +112,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
   thread_local auto generator = std::ranlux48();
   auto items = std::map<uint16_t, std::size_t>();
-  uint16_t epoch = 1;
+  uint16_t epoch = 0;
   for (uint16_t size = 1; size <= 1 << 12; ++size) {
     items.emplace(size, static_cast<std::size_t>(std::rand() % (1 << 15)));
   }


### PR DESCRIPTION
This PR adds test code checking whether intra-batch shuffling is deterministic.

Output using ``make test`` :

```
Test project /home/flatflow/build
    Start 1: DatasetTest.Constructor
1/2 Test #1: DatasetTest.Constructor ...........   Passed    1.00 sec
    Start 2: DatasetTest.IntraBatchShuffling
2/2 Test #2: DatasetTest.IntraBatchShuffling ...   Passed    8.24 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   9.26 sec
```

Test log:

```
2/2 Testing: DatasetTest.IntraBatchShuffling
2/2 Test: DatasetTest.IntraBatchShuffling
Command: "/home/flatflow/build/flatflow/data/dataset_test" "--gtest_filter=DatasetTest.IntraBatchShuffling"
Directory: /home/flatflow/build/flatflow/data
"DatasetTest.IntraBatchShuffling" start time: Mar 19 05:41 UTC
Output:
----------------------------------------------------------
Running main() from /home/flatflow/thirdparty/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = DatasetTest.IntraBatchShuffling
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DatasetTest
[ RUN      ] DatasetTest.IntraBatchShuffling
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1710826865.691618   36657 dataset.h:130] Construction of inverted index took 0.449739 seconds
I0000 00:00:1710826869.294529   36657 dataset.h:234] Epoch: 0 intra-batch shuffling took 3.602154 seconds
[       OK ] DatasetTest.IntraBatchShuffling (8217 ms)
[----------] 1 test from DatasetTest (8217 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (8217 ms total)
[  PASSED  ] 1 test.
<end of output>
Test time =   8.24 sec
----------------------------------------------------------
Test Passed.
"DatasetTest.IntraBatchShuffling" end time: Mar 19 05:41 UTC
"DatasetTest.IntraBatchShuffling" time elapsed: 00:00:08
----------------------------------------------------------

End testing: Mar 19 05:41 UTC
```