### PR TITLE
data: add unit test for index retriever

### DIFF
--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -184,18 +184,6 @@ TEST(DatasetTest, IntraBatchShuffling) {
     slots.at(size).emplace_back(index);
   }
 
-  // Expects dataset and slots are not equal.
-  // Since, dataset is shuffled and slots are not.
-  for (std::size_t size = 0; size < counts.size(); ++size) {
-    const auto count = counts.at(size);
-    if (0 < count) {
-      const auto &dataset_vector = dataset.at(size);
-      const auto &current_vector = slots.at(size);
-      EXPECT_FALSE(std::equal(dataset_vector.begin(), dataset_vector.end(),
-                              current_vector.begin()));
-    }
-  }
-
   thread_local auto generator = std::ranlux48();
 
 // clang-format off

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -37,26 +37,26 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
     return items.contains(size);
   }
 
-  inline std::size_t size(uint16_t size, bool items = true) const noexcept {
-    return items ? items.at(size).size() : recyclebin.at(size).size();
+  inline std::size_t size(uint16_t size, bool item = true) const noexcept {
+    return item ? items.at(size).size() : recyclebin.at(size).size();
   }
 
-  inline std::size_t capacity(uint16_t size, bool items = true) const noexcept {
-    return items ? items.at(size).capacity() : recyclebin.at(size).capacity();
+  inline std::size_t capacity(uint16_t size, bool item = true) const noexcept {
+    return item ? items.at(size).capacity() : recyclebin.at(size).capacity();
   }
 
   inline bool is_sorted(uint16_t size) const noexcept {
     return std::is_sorted(items.at(size).cbegin(), items.at(size).cend());
   }
 
-  inline bool empty(bool items = true) const noexcept {
-    return items ? items.empty() : recyclebin.empty();
+  inline bool empty(bool item = true) const noexcept {
+    return item ? items.empty() : recyclebin.empty();
   }
 
   inline void shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
 
-  inline std::vector<uint64_t> &at(uint16_t size, bool items = true) noexcept {
-    return items ? items.at(size) : recyclebin.at(size);
+  inline std::vector<uint64_t> &at(uint16_t size, bool item = true) noexcept {
+    return item ? items.at(size) : recyclebin.at(size);
   }
 
   inline std::pair<uint64_t, uint16_t> retrieve(uint16_t size) {

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -70,7 +70,7 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
 
   inline void shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
  
-  inline const std::vector<uint64_t> &at(uint16_t size, bool checkItem=true) const noexcept {
+  inline std::vector<uint64_t> &at(uint16_t size, bool checkItem=true) noexcept{
     if (checkItem) {
       return items.at(size);
     }
@@ -344,14 +344,14 @@ TEST(DatasetTest, IndexRetriever){
   EXPECT_EQ(dataset.capacity(40, false), 1);
 
   // check if recyclebin vectors are all reverted.
-  // std::reverse(dataset.at(10, false).begin(), dataset.at(10, false).end());
-  // EXPECT_TRUE(std::is_sorted(dataset.at(10, false).begin(), dataset.at(10, false).end()));
-  // std::reverse(dataset.at(20, false).begin(), dataset.at(20, false).end());
-  // EXPECT_TRUE(std::is_sorted(dataset.at(20, false).begin(), dataset.at(20, false).end()));
-  // std::reverse(dataset.at(30, false).begin(), dataset.at(30, false).end());
-  // EXPECT_TRUE(std::is_sorted(dataset.at(30, false).begin(), dataset.at(30, false).end()));
-  // std::reverse(dataset.at(40, false).begin(), dataset.at(40, false).end());
-  // EXPECT_TRUE(std::is_sorted(dataset.at(40, false).begin(), dataset.at(40, false).end()));
+  std::reverse(dataset.at(10, false).begin(), dataset.at(10, false).end());
+  EXPECT_TRUE(std::is_sorted(dataset.at(10, false).begin(), dataset.at(10, false).end()));
+  std::reverse(dataset.at(20, false).begin(), dataset.at(20, false).end());
+  EXPECT_TRUE(std::is_sorted(dataset.at(20, false).begin(), dataset.at(20, false).end()));
+  std::reverse(dataset.at(30, false).begin(), dataset.at(30, false).end());
+  EXPECT_TRUE(std::is_sorted(dataset.at(30, false).begin(), dataset.at(30, false).end()));
+  std::reverse(dataset.at(40, false).begin(), dataset.at(40, false).end());
+  EXPECT_TRUE(std::is_sorted(dataset.at(40, false).begin(), dataset.at(40, false).end()));
 }
 
 }  // namespace

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -110,9 +110,9 @@ TEST(DatasetTest, IntraBatchShuffling) {
   // * Last, we check if the slots and dataset vectors are equal. 
 
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
-  thread_local auto generator = std::ranlux48();
   auto items = std::map<uint16_t, std::size_t>();
   uint16_t epoch = 0;
+
   for (uint16_t size = 1; size <= 1 << 12; ++size) {
     items.emplace(size, static_cast<std::size_t>(std::rand() % (1 << 15)));
   }
@@ -195,6 +195,9 @@ TEST(DatasetTest, IntraBatchShuffling) {
                               current_vector.begin()));
     }
   }
+
+  thread_local auto generator = std::ranlux48();
+
 // clang-format off
   #pragma omp parallel for
   // clang-format on

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -158,7 +158,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   auto counts =
       absl::InlinedVector<uint64_t, kIndexSlotSpace>(kIndexSlotSpace, 0);
 
-#pragma omp unroll partial
+  #pragma omp unroll partial
   for (uint64_t index = 0; index < sizes.size(); ++index) {
     const auto size = static_cast<std::size_t>(sizes[index]);
     ++counts.at(size);
@@ -167,7 +167,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   auto slots = absl::InlinedVector<std::vector<uint64_t>, kIndexSlotSpace>(
       kIndexSlotSpace);
 
-#pragma omp parallel for
+  #pragma omp parallel for
   for (std::size_t size = 0; size < counts.size(); ++size) {
     const auto count = counts.at(size);
     if (0 < count) {
@@ -175,7 +175,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
     }
   }
 
-#pragma omp unroll partial
+  #pragma omp unroll partial
   for (uint64_t index = 0; index < sizes.size(); ++index) {
     const auto size = static_cast<std::size_t>(sizes[index]);
     slots.at(size).emplace_back(index);
@@ -183,7 +183,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
 
   thread_local auto generator = std::ranlux48();
 
-#pragma omp parallel for
+  #pragma omp parallel for
   for (auto &item : slots) {
     generator.seed(static_cast<uint_fast64_t>(0UL + epoch));
     std::shuffle(item.begin(), item.end(), generator);

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -99,8 +99,8 @@ TEST(DatasetTest, Constructor) {
   EXPECT_TRUE(dataset.empty());
 }
 
-TEST(DatasetTest, IntraShuffle) {
-  // Test case for IntraShuffle
+TEST(DatasetTest, IntraBatchShuffling) {
+  // Test case for IntraBatchShuffling
   //
   // NOTE:
   //

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "flatflow/data/dataset.h"
+
 #include <cstdlib>
 #include <ctime>
 #include <map>
@@ -21,7 +23,6 @@
 #include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
 
-#include "flatflow/data/dataset.h"
 #include "flatflow/data/dataset_test.h"
 
 namespace {

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -99,6 +99,15 @@ TEST(DatasetTest, Constructor) {
 }
 
 TEST(DatasetTest, IntraShuffle) {
+  // Test case for IntraShuffle
+  //
+  // NOTE:
+  //
+  // * We first check if the dataset vectors are sorted.
+  // * After shuffling, we check if dataset vectors are not sorted.
+  // * Then using the same input vector, we shuffle the slots.
+  // * Last, we check if the slots and dataset vectors are equal. 
+
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
   thread_local auto generator = std::ranlux48();
   auto items = std::map<uint16_t, std::size_t>();
@@ -185,7 +194,9 @@ TEST(DatasetTest, IntraShuffle) {
                               current_vector.begin()));
     }
   }
-
+// clang-format off
+  #pragma omp parallel for
+  // clang-format on
   for (auto &item : slots) {
     generator.seed(static_cast<uint_fast64_t>(0UL + epoch));
     std::shuffle(item.begin(), item.end(), generator);

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -221,6 +221,8 @@ TEST(DatasetTest, IndexRetriever){
   // Test case 2 : When the size is not in the dataset.
   // Test case 3 : When only one index of the size is left.
   // 
+  // After retrieving all indexes from the items, check if the dataset is empty and the size of the recyclebin is correct.
+  // At the end, check if the recyclebin vectors are all in reverted order.
 
   std::vector<uint16_t> sizes = {10, 10, 10, 20, 20, 30, 30, 30, 30, 40};
   auto builder = flatbuffers::FlatBufferBuilder64();

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -37,20 +37,19 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
     return items.contains(size);
   }
 
-  inline std::size_t size(uint16_t size,bool checkItem=true) const noexcept {
+  inline std::size_t size(uint16_t size, bool checkItem = true) const noexcept {
     if (checkItem) {
       return items.at(size).size();
-    }
-    else {
+    } else {
       return recyclebin.at(size).size();
     }
   }
 
-  inline std::size_t capacity(uint16_t size, bool checkItem=true) const noexcept {
+  inline std::size_t capacity(uint16_t size,
+                              bool checkItem = true) const noexcept {
     if (checkItem) {
       return items.at(size).capacity();
-    }
-    else {
+    } else {
       return recyclebin.at(size).capacity();
     }
   }
@@ -59,22 +58,21 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
     return std::is_sorted(items.at(size).cbegin(), items.at(size).cend());
   }
 
-  inline bool empty(bool checkItem=true) const noexcept { 
+  inline bool empty(bool checkItem = true) const noexcept {
     if (checkItem) {
       return items.empty();
-    }
-    else {
+    } else {
       return recyclebin.empty();
     }
   }
 
   inline void shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
- 
-  inline std::vector<uint64_t> &at(uint16_t size, bool checkItem=true) noexcept{
+
+  inline std::vector<uint64_t> &at(uint16_t size,
+                                   bool checkItem = true) noexcept {
     if (checkItem) {
       return items.at(size);
-    }
-    else {
+    } else {
       return recyclebin.at(size);
     }
   }
@@ -205,7 +203,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   }
 }
 
-TEST(DatasetTest, IndexRetriever){
+TEST(DatasetTest, IndexRetriever) {
   // Note:
   //
   // Test sample looks like below items.
@@ -220,9 +218,10 @@ TEST(DatasetTest, IndexRetriever){
   // Test case 1 : When the size is in the dataset.
   // Test case 2 : When the size is not in the dataset.
   // Test case 3 : When only one index of the size is left.
-  // 
-  // After retrieving all indexes from the items, check if the dataset is empty and the size of the recyclebin is correct.
-  // At the end, check if the recyclebin vectors are all in reverted order.
+  //
+  // After retrieving all indexes from the items, check if the dataset is empty
+  // and the size of the recyclebin is correct. At the end, check if the
+  // recyclebin vectors are all in reverted order.
 
   std::vector<uint16_t> sizes = {10, 10, 10, 20, 20, 30, 30, 30, 30, 40};
   auto builder = flatbuffers::FlatBufferBuilder64();
@@ -234,106 +233,111 @@ TEST(DatasetTest, IndexRetriever){
   auto dataset = DatasetTest(sizes_->sizes(), 0UL);
 
   // Test case 1
-  // Expected behavior : Dataset will retrieve a pair of index and size from the dataset.
+  // Expected behavior : Dataset will retrieve a pair of index and size from the
+  // dataset.
   uint16_t size = 20;
   auto result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 4); 
+  EXPECT_EQ(result.first, 4);
   EXPECT_EQ(result.second, size);
-  EXPECT_EQ(dataset.size(size), 1); 
+  EXPECT_EQ(dataset.size(size), 1);
   EXPECT_EQ(dataset.size(size, false), 1);
 
-
   // Test case 2
-  // Expected behaivor : Dataset will retrieve closest size's pair for size which will be 10.
+  // Expected behaivor : Dataset will retrieve closest size's pair for size
+  // which will be 10.
   size = 8;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 2); 
-  EXPECT_EQ(result.second, 10); 
-  EXPECT_EQ(dataset.size(10, false), 1); 
-  EXPECT_EQ(dataset.size(10), 2); 
+  EXPECT_EQ(result.first, 2);
+  EXPECT_EQ(result.second, 10);
+  EXPECT_EQ(dataset.size(10, false), 1);
+  EXPECT_EQ(dataset.size(10), 2);
   EXPECT_EQ(dataset.capacity(10, false), 3);
 
   // Test case 3
   // Expected behavior : items will erase size 40 from the dataset.
   size = 40;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 9); 
-  EXPECT_EQ(result.second, size); 
-  EXPECT_EQ(dataset.size(size, false), 1); 
+  EXPECT_EQ(result.first, 9);
+  EXPECT_EQ(result.second, size);
+  EXPECT_EQ(dataset.size(size, false), 1);
   EXPECT_EQ(dataset.capacity(size, false), 1);
 
   // Test case 3
   // Expected behavior : Size 20 will be removed from the dataset.
-  size = 20; 
+  size = 20;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 3); 
-  EXPECT_EQ(result.second, size); 
-  EXPECT_EQ(dataset.size(size, false), 2); 
+  EXPECT_EQ(result.first, 3);
+  EXPECT_EQ(result.second, size);
+  EXPECT_EQ(dataset.size(size, false), 2);
   EXPECT_EQ(dataset.capacity(size, false), 2);
 
   // Test case 2
-  // Expected behavior : Dataset will retrieve closest size's pair for size which will be 30.
+  // Expected behavior : Dataset will retrieve closest size's pair for size
+  // which will be 30.
   size = 28;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 8); 
-  EXPECT_EQ(result.second, 30); 
-  EXPECT_EQ(dataset.size(30, false), 1); 
+  EXPECT_EQ(result.first, 8);
+  EXPECT_EQ(result.second, 30);
+  EXPECT_EQ(dataset.size(30, false), 1);
   EXPECT_EQ(dataset.size(30), 3);
   EXPECT_EQ(dataset.capacity(30, false), 4);
 
   // Test case 2
-  // Expected behavior : Dataset will retrieve closest size's pair for size which will be 30.
+  // Expected behavior : Dataset will retrieve closest size's pair for size
+  // which will be 30.
   size = 31;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 7); 
-  EXPECT_EQ(result.second, 30); 
-  EXPECT_EQ(dataset.size(30, false), 2); 
+  EXPECT_EQ(result.first, 7);
+  EXPECT_EQ(result.second, 30);
+  EXPECT_EQ(dataset.size(30, false), 2);
   EXPECT_EQ(dataset.size(30), 2);
   EXPECT_EQ(dataset.capacity(30, false), 4);
 
   // Test case 1
-  // Expected behavior : Dataset will retrieve a pair of index and size from the dataset.
+  // Expected behavior : Dataset will retrieve a pair of index and size from the
+  // dataset.
   size = 30;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 6); 
-  EXPECT_EQ(result.second, size); 
+  EXPECT_EQ(result.first, 6);
+  EXPECT_EQ(result.second, size);
   EXPECT_EQ(dataset.size(size, false), 3);
-  EXPECT_EQ(dataset.size(size), 1); 
+  EXPECT_EQ(dataset.size(size), 1);
   EXPECT_EQ(dataset.capacity(size, false), 4);
 
   // Test case 2 & 3
   // Expected behavior : Size 30 will be removed from the dataset.
-  size = 34; 
+  size = 34;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 5); 
-  EXPECT_EQ(result.second, 30); 
-  EXPECT_EQ(dataset.size(30, false), 4); 
-  EXPECT_FALSE(dataset.contains(30)); 
+  EXPECT_EQ(result.first, 5);
+  EXPECT_EQ(result.second, 30);
+  EXPECT_EQ(dataset.size(30, false), 4);
+  EXPECT_FALSE(dataset.contains(30));
   EXPECT_EQ(dataset.capacity(30, false), 4);
 
   // Test case 1
-  // Expected behavior : Dataset will retrieve a pair of index and size from the dataset.
+  // Expected behavior : Dataset will retrieve a pair of index and size from the
+  // dataset.
   size = 10;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 1); 
+  EXPECT_EQ(result.first, 1);
   EXPECT_EQ(result.second, size);
-  EXPECT_EQ(dataset.size(size), 1); 
+  EXPECT_EQ(dataset.size(size), 1);
   EXPECT_EQ(dataset.size(size, false), 2);
   EXPECT_EQ(dataset.capacity(size, false), 3);
 
   // Test case 3
   // Expected behavior : Size 10 will be removed from the dataset.
-  size = 10; 
+  size = 10;
   result = dataset.retrieveItem(size);
-  EXPECT_EQ(result.first, 0); 
-  EXPECT_EQ(result.second, size); 
-  EXPECT_EQ(dataset.size(size, false), 3); 
+  EXPECT_EQ(result.first, 0);
+  EXPECT_EQ(result.second, size);
+  EXPECT_EQ(dataset.size(size, false), 3);
   EXPECT_EQ(dataset.capacity(size, false), 3);
 
   // Check if items is empty.
   EXPECT_TRUE(dataset.empty(true));
 
-  // check size of recyclebin. 
+  // check size of recyclebin.
   EXPECT_EQ(dataset.size(10, false), 3);
   EXPECT_EQ(dataset.size(20, false), 2);
   EXPECT_EQ(dataset.size(30, false), 4);
@@ -347,13 +351,17 @@ TEST(DatasetTest, IndexRetriever){
 
   // check if recyclebin vectors are all reverted.
   std::reverse(dataset.at(10, false).begin(), dataset.at(10, false).end());
-  EXPECT_TRUE(std::is_sorted(dataset.at(10, false).begin(), dataset.at(10, false).end()));
+  EXPECT_TRUE(std::is_sorted(dataset.at(10, false).begin(),
+                             dataset.at(10, false).end()));
   std::reverse(dataset.at(20, false).begin(), dataset.at(20, false).end());
-  EXPECT_TRUE(std::is_sorted(dataset.at(20, false).begin(), dataset.at(20, false).end()));
+  EXPECT_TRUE(std::is_sorted(dataset.at(20, false).begin(),
+                             dataset.at(20, false).end()));
   std::reverse(dataset.at(30, false).begin(), dataset.at(30, false).end());
-  EXPECT_TRUE(std::is_sorted(dataset.at(30, false).begin(), dataset.at(30, false).end()));
+  EXPECT_TRUE(std::is_sorted(dataset.at(30, false).begin(),
+                             dataset.at(30, false).end()));
   std::reverse(dataset.at(40, false).begin(), dataset.at(40, false).end());
-  EXPECT_TRUE(std::is_sorted(dataset.at(40, false).begin(), dataset.at(40, false).end()));
+  EXPECT_TRUE(std::is_sorted(dataset.at(40, false).begin(),
+                             dataset.at(40, false).end()));
 }
 
 }  // namespace

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "flatflow/data/dataset.h"
+
 
 #include <cstdlib>
 #include <ctime>
@@ -21,7 +21,9 @@
 
 #include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
+#include <absl/container/inlined_vector.h>
 
+#include "flatflow/data/dataset.h"
 #include "flatflow/data/dataset_test.h"
 
 namespace {
@@ -49,6 +51,14 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
   }
 
   inline bool empty() const noexcept { return recyclebin.empty(); }
+
+  inline void intra_shuffle(auto epoch){
+    on_epoch_begin(epoch);
+  }
+
+  inline std::vector<uint64_t> access_vector(uint16_t size) const noexcept{
+    return items.at(size);
+  }
 };
 
 TEST(DatasetTest, Constructor) {
@@ -90,6 +100,93 @@ TEST(DatasetTest, Constructor) {
     }
   }
   EXPECT_TRUE(dataset.empty());
+}
+
+TEST(DatasetTest, IntraShuffle) {
+  std::srand(static_cast<unsigned int>(std::time(nullptr)));
+  thread_local auto generator = std::ranlux48();
+  auto items = std::map<uint16_t, std::size_t>();
+  for (uint16_t size = 1; size <= 1 << 12; ++size) {
+    items.emplace(size, static_cast<std::size_t>(std::rand() % (1 << 15)));
+  }
+
+  auto sizes = std::vector<uint16_t>();
+  for (const auto item : items) {
+    const auto size = item.first;
+    auto count = item.second;
+    for (; 0 < count; --count) {
+      sizes.push_back(size);
+    }
+  }
+  sizes.shrink_to_fit();
+
+  auto builder = flatbuffers::FlatBufferBuilder64();
+  auto sizes__ = builder.CreateVector64(sizes);
+  auto offset = CreateSizes(builder, sizes__);
+  builder.Finish(offset);
+  auto sizes_ = GetSizes(builder.GetBufferPointer());
+  auto dataset = DatasetTest(sizes_->sizes(), 0UL);
+
+  for (const auto& item: items){
+    const auto& size = item.first;
+    EXPECT_TRUE(dataset.is_sorted(size));
+  }
+  // call on_epoch_begin for shuffle.
+  dataset.intra_shuffle(0); 
+  for (const auto& item: items){
+    const auto& size = item.first;
+    EXPECT_FALSE(dataset.is_sorted(size));
+  }
+  constexpr auto kIndexSlotSpace =
+    static_cast<std::size_t>(1 << std::numeric_limits<uint16_t>::digits);
+  auto counts =
+    absl::InlinedVector<uint64_t, kIndexSlotSpace>(kIndexSlotSpace, 0);
+
+  // clang-format off
+  #pragma omp unroll partial
+  // clang-format on
+  for (uint64_t index = 0; index < sizes.size(); ++index) {
+    const auto size = static_cast<std::size_t>(sizes[index]);
+    ++counts.at(size);
+  }
+
+  auto slots = absl::InlinedVector<std::vector<uint64_t>, kIndexSlotSpace>(
+      kIndexSlotSpace);
+
+  // clang-format off
+  #pragma omp parallel for
+  // clang-format on
+  for (std::size_t size = 0; size < counts.size(); ++size) {
+    const auto count = counts.at(size);
+    if (0 < count) {
+      slots.at(size).reserve(static_cast<std::size_t>(count));
+    }
+  }
+
+  // clang-format off
+  #pragma omp unroll partial
+  // clang-format on
+  for (uint64_t index = 0; index < sizes.size(); ++index) {
+    const auto size = static_cast<std::size_t>(sizes[index]);
+    slots.at(size).emplace_back(index);
+  }
+
+  //clang-format off
+  #pragma omp parallel for
+  // clang-format on
+  for (auto &item : slots) {
+    generator.seed(static_cast<uint_fast64_t>(0UL + 0));
+    std::shuffle(item.begin(), item.end(), generator);
+  }
+
+  for (std::size_t size = 0; size < counts.size(); ++size) {
+    const auto count = counts.at(size);
+    if (0 < count) {
+      const auto& dataset_vector = dataset.access_vector(size);
+      const auto& current_vector = slots.at(size);
+      EXPECT_TRUE(std::equal(dataset_vector.begin(),dataset_vector.end(),current_vector.begin()));
+    }
+  }
 }
 
 }  // namespace

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -78,7 +78,7 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
   }
 
   inline std::pair<uint64_t, uint16_t> retrieveItem(uint16_t size) {
-    return (*this)[size];
+    return find(size);
   }
 };
 
@@ -158,7 +158,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   auto counts =
       absl::InlinedVector<uint64_t, kIndexSlotSpace>(kIndexSlotSpace, 0);
 
-  #pragma omp unroll partial
+#pragma omp unroll partial
   for (uint64_t index = 0; index < sizes.size(); ++index) {
     const auto size = static_cast<std::size_t>(sizes[index]);
     ++counts.at(size);
@@ -167,7 +167,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   auto slots = absl::InlinedVector<std::vector<uint64_t>, kIndexSlotSpace>(
       kIndexSlotSpace);
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (std::size_t size = 0; size < counts.size(); ++size) {
     const auto count = counts.at(size);
     if (0 < count) {
@@ -175,7 +175,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
     }
   }
 
-  #pragma omp unroll partial
+#pragma omp unroll partial
   for (uint64_t index = 0; index < sizes.size(); ++index) {
     const auto size = static_cast<std::size_t>(sizes[index]);
     slots.at(size).emplace_back(index);
@@ -183,7 +183,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
 
   thread_local auto generator = std::ranlux48();
 
-  #pragma omp parallel for
+#pragma omp parallel for
   for (auto &item : slots) {
     generator.seed(static_cast<uint_fast64_t>(0UL + epoch));
     std::shuffle(item.begin(), item.end(), generator);

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -37,47 +37,29 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
     return items.contains(size);
   }
 
-  inline std::size_t size(uint16_t size, bool checkItem = true) const noexcept {
-    if (checkItem) {
-      return items.at(size).size();
-    } else {
-      return recyclebin.at(size).size();
-    }
+  inline std::size_t size(uint16_t size, bool items = true) const noexcept {
+    return items ? items.at(size).size() : recyclebin.at(size).size();
   }
 
-  inline std::size_t capacity(uint16_t size,
-                              bool checkItem = true) const noexcept {
-    if (checkItem) {
-      return items.at(size).capacity();
-    } else {
-      return recyclebin.at(size).capacity();
-    }
+  inline std::size_t capacity(uint16_t size, bool items = true) const noexcept {
+    return items ? items.at(size).capacity() : recyclebin.at(size).capacity();
   }
 
   inline bool is_sorted(uint16_t size) const noexcept {
     return std::is_sorted(items.at(size).cbegin(), items.at(size).cend());
   }
 
-  inline bool empty(bool checkItem = true) const noexcept {
-    if (checkItem) {
-      return items.empty();
-    } else {
-      return recyclebin.empty();
-    }
+  inline bool empty(bool items = true) const noexcept {
+    return items ? items.empty() : recyclebin.empty();
   }
 
   inline void shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
 
-  inline std::vector<uint64_t> &at(uint16_t size,
-                                   bool checkItem = true) noexcept {
-    if (checkItem) {
-      return items.at(size);
-    } else {
-      return recyclebin.at(size);
-    }
+  inline std::vector<uint64_t> &at(uint16_t size, bool items = true) noexcept {
+    return items ? items.at(size) : recyclebin.at(size);
   }
 
-  inline std::pair<uint64_t, uint16_t> retrieveItem(uint16_t size) {
+  inline std::pair<uint64_t, uint16_t> retrieve(uint16_t size) {
     return find(size);
   }
 };
@@ -204,7 +186,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
 }
 
 TEST(DatasetTest, IndexRetriever) {
-  // Note:
+  // NOTE:
   //
   // Test sample looks like below items.
   // std::unordered_map<int, std::vector<int>> items = {
@@ -236,7 +218,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Expected behavior : Dataset will retrieve a pair of index and size from the
   // dataset.
   uint16_t size = 20;
-  auto result = dataset.retrieveItem(size);
+  auto result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 4);
   EXPECT_EQ(result.second, size);
   EXPECT_EQ(dataset.size(size), 1);
@@ -246,7 +228,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Expected behaivor : Dataset will retrieve closest size's pair for size
   // which will be 10.
   size = 8;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 2);
   EXPECT_EQ(result.second, 10);
   EXPECT_EQ(dataset.size(10, false), 1);
@@ -256,7 +238,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Test case 3
   // Expected behavior : items will erase size 40 from the dataset.
   size = 40;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 9);
   EXPECT_EQ(result.second, size);
   EXPECT_EQ(dataset.size(size, false), 1);
@@ -265,7 +247,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Test case 3
   // Expected behavior : Size 20 will be removed from the dataset.
   size = 20;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 3);
   EXPECT_EQ(result.second, size);
   EXPECT_EQ(dataset.size(size, false), 2);
@@ -275,7 +257,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Expected behavior : Dataset will retrieve closest size's pair for size
   // which will be 30.
   size = 28;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 8);
   EXPECT_EQ(result.second, 30);
   EXPECT_EQ(dataset.size(30, false), 1);
@@ -286,7 +268,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Expected behavior : Dataset will retrieve closest size's pair for size
   // which will be 30.
   size = 31;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 7);
   EXPECT_EQ(result.second, 30);
   EXPECT_EQ(dataset.size(30, false), 2);
@@ -297,7 +279,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Expected behavior : Dataset will retrieve a pair of index and size from the
   // dataset.
   size = 30;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 6);
   EXPECT_EQ(result.second, size);
   EXPECT_EQ(dataset.size(size, false), 3);
@@ -307,7 +289,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Test case 2 & 3
   // Expected behavior : Size 30 will be removed from the dataset.
   size = 34;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 5);
   EXPECT_EQ(result.second, 30);
   EXPECT_EQ(dataset.size(30, false), 4);
@@ -318,7 +300,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Expected behavior : Dataset will retrieve a pair of index and size from the
   // dataset.
   size = 10;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 1);
   EXPECT_EQ(result.second, size);
   EXPECT_EQ(dataset.size(size), 1);
@@ -328,7 +310,7 @@ TEST(DatasetTest, IndexRetriever) {
   // Test case 3
   // Expected behavior : Size 10 will be removed from the dataset.
   size = 10;
-  result = dataset.retrieveItem(size);
+  result = dataset.retrieve(size);
   EXPECT_EQ(result.first, 0);
   EXPECT_EQ(result.second, size);
   EXPECT_EQ(dataset.size(size, false), 3);

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -51,9 +51,9 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
 
   inline bool empty() const noexcept { return recyclebin.empty(); }
 
-  inline void epoch_begin(uint64_t epoch) { on_epoch_begin(epoch); }
+  inline void shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
  
-  inline const std::vector<uint64_t>& at(uint16_t size) const noexcept {
+  inline const std::vector<uint64_t> &at(uint16_t size) const noexcept {
     return items.at(size);
   }
 };
@@ -100,15 +100,6 @@ TEST(DatasetTest, Constructor) {
 }
 
 TEST(DatasetTest, IntraBatchShuffling) {
-  // Test case for Intra-BatchShuffling
-  //
-  // NOTE:
-  //
-  // * We first check if the dataset vectors are sorted.
-  // * After shuffling, we check if dataset vectors are not sorted.
-  // * Then using the same input vector, we shuffle the slots.
-  // * Last, we check if the slots and dataset vectors are equal. 
-
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
   auto items = std::map<uint16_t, std::size_t>();
   uint16_t epoch = 0;
@@ -136,7 +127,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   auto dataset = DatasetTest(sizes_->sizes(), 0UL);
 
   // call on_epoch_begin for shuffle.
-  dataset.epoch_begin(epoch);
+  dataset.shuffle(epoch);
 
   constexpr auto kIndexSlotSpace =
       static_cast<std::size_t>(1 << std::numeric_limits<uint16_t>::digits);

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -196,7 +196,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
 TEST(DatasetTest, IndexRetriever){
   // Note:
   //
-  // Test dataset looks like below items.
+  // Test sample looks like below items.
   // std::unordered_map<int, std::vector<int>> items = {
   //       {10, {0, 1, 2}},
   //       {20, {3, 4}},

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -50,9 +50,9 @@ class DatasetTest final : private flatflow::data::Dataset<uint64_t, uint16_t> {
 
   inline bool empty() const noexcept { return recyclebin.empty(); }
 
-  inline void intra_shuffle(uint64_t epoch) { on_epoch_begin(epoch); }
+  inline void on_epoch_begin(uint64_t epoch) { on_epoch_begin(epoch); }
 
-  inline std::vector<uint64_t> access_vector(uint16_t size) const noexcept {
+  inline std::vector<uint64_t> at(uint16_t size) const noexcept {
     return items.at(size);
   }
 };
@@ -141,7 +141,7 @@ TEST(DatasetTest, IntraShuffle) {
   }
 
   // call on_epoch_begin for shuffle.
-  dataset.intra_shuffle(epoch);
+  dataset.on_epoch_begin(epoch);
 
   // Expects all vectors are not sorted.
   for (const auto &item : items) {
@@ -188,7 +188,7 @@ TEST(DatasetTest, IntraShuffle) {
   for (std::size_t size = 0; size < counts.size(); ++size) {
     const auto count = counts.at(size);
     if (0 < count) {
-      const auto &dataset_vector = dataset.access_vector(size);
+      const auto &dataset_vector = dataset.at(size);
       const auto &current_vector = slots.at(size);
       EXPECT_FALSE(std::equal(dataset_vector.begin(), dataset_vector.end(),
                               current_vector.begin()));

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -112,7 +112,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
   thread_local auto generator = std::ranlux48();
   auto items = std::map<uint16_t, std::size_t>();
-  uint16_t epoch = 1;
+  uint16_t epoch = 0;
   for (uint16_t size = 1; size <= 1 << 12; ++size) {
     items.emplace(size, static_cast<std::size_t>(std::rand() % (1 << 15)));
   }


### PR DESCRIPTION
This PR adds test code checking whether retrieval process of a data sample is correct.
Output using ``make test`` :

```
Test project /home/flatflow/build
    Start 1: DatasetTest.Constructor
1/3 Test #1: DatasetTest.Constructor ...........   Passed    0.81 sec
    Start 2: DatasetTest.IntraBatchShuffling
2/3 Test #2: DatasetTest.IntraBatchShuffling ...   Passed    8.33 sec
    Start 3: DatasetTest.IndexRetriever
3/3 Test #3: DatasetTest.IndexRetriever ........   Passed    0.00 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   9.17 sec
```
Test log:

```
3/3 Testing: DatasetTest.IndexRetriever
3/3 Test: DatasetTest.IndexRetriever
Command: "/home/flatflow/build/flatflow/data/dataset_test" "--gtest_filter=DatasetTest.IndexRetriever"
Directory: /home/flatflow/build/flatflow/data
"DatasetTest.IndexRetriever" start time: Mar 28 02:10 UTC
Output:
----------------------------------------------------------
Running main() from /home/flatflow/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = DatasetTest.IndexRetriever
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DatasetTest
[ RUN      ] DatasetTest.IndexRetriever
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1711591850.384404    8026 dataset.h:126] Construction of inverted index took 0.000854 seconds
[       OK ] DatasetTest.IndexRetriever (0 ms)
[----------] 1 test from DatasetTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
<end of output>
Test time =   0.00 sec
----------------------------------------------------------
Test Passed.
"DatasetTest.IndexRetriever" end time: Mar 28 02:10 UTC
"DatasetTest.IndexRetriever" time elapsed: 00:00:00
----------------------------------------------------------

End testing: Mar 28 02:10 UTC

```