### PR TITLE
data : fix bug in intra-batch shuffling test

### DIFF
--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -175,7 +175,7 @@ TEST(DatasetTest, IntraBatchShuffling) {
   // Since, slots are shuffled.
   for (std::size_t size = 0; size < counts.size(); ++size) {
     const auto count = counts.at(size);
-    if (0 < count) {
+    if (1 < count) {
       const auto &dataset_vector = dataset.at(size);
       const auto &current_vector = slots.at(size);
       EXPECT_FALSE(dataset.is_sorted(size));


### PR DESCRIPTION
This PR fixes the intra-batch shuffling unit test bug.
Previous intra-batch shuffling unit test occasionally failed since it checks whether a vector of length 1 is not sorted.
This can be fixed by changing the if statement.