### PR TITLE
scheduler: add unit test for static scheduler

### DIFF
--- a/flatflow/scheduler/CMakeLists.txt
+++ b/flatflow/scheduler/CMakeLists.txt
@@ -12,5 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(data)
-add_subdirectory(scheduler)
+if(BUILD_TESTING)
+  add_executable(
+    scheduler_test
+    scheduler_test.cc)
+  target_include_directories(
+    scheduler_test
+    PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(
+    scheduler_test
+    PRIVATE absl::btree
+    PRIVATE absl::inlined_vector
+    PRIVATE absl::log
+    PRIVATE absl::str_format
+    PRIVATE flatbuffers
+    PRIVATE GTest::gtest_main
+    PRIVATE OpenMP::OpenMP_CXX)
+  gtest_add_tests(
+    TARGET scheduler_test)
+endif()

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -54,7 +54,8 @@ TEST(SchedulerTest, StaticScheduler) {
 
   auto items = std::map<uint16_t, std::size_t>();
   for (uint16_t size = 1; size <= datasetsize; ++size) {
-    items.emplace(size, static_cast<std::size_t>(std::rand() % (datasetsize)));
+    // items.emplace(size, static_cast<std::size_t>(std::rand() % (datasetsize)));
+    items.emplace(size, static_cast<std::size_t>(1));
   }
 
   auto sizes = std::vector<uint16_t>();
@@ -108,7 +109,8 @@ TEST(SchedulerTest, StaticSchedulerWithRemainder) {
 
   auto items = std::map<uint16_t, std::size_t>();
   for (uint16_t size = 1; size <= datasetsize; ++size) {
-    items.emplace(size, static_cast<std::size_t>(std::rand() % (datasetsize)));
+    // items.emplace(size, static_cast<std::size_t>(std::rand() % (datasetsize)));
+    items.emplace(size, static_cast<std::size_t>(1));
   }
 
   auto sizes = std::vector<uint16_t>();

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -102,7 +102,7 @@ TEST(SchedulerTest, StaticScheduler) {
 TEST(SchedulerTest, StaticSchedulerWithRemainder) {
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
-  auto datasetsize = 1 << 10 + 1 << 3;
+  auto datasetsize = (1 << 10) + (1 << 3);
   const auto world_size = 1 << 2;
   auto batch_size = 1 << 5;
   auto seed = 0UL;
@@ -133,7 +133,7 @@ TEST(SchedulerTest, StaticSchedulerWithRemainder) {
   auto scheduler = SchedulerTest(sizes_->sizes(), world_size, batch_size, seed);
   scheduler.train_begin();
   for (auto epoch = 0; epoch < 10; ++epoch) {
-    for (auto step = 0; step < datasetsize / batch_size + 1; ++step) {
+    for (auto step = 0; step < (datasetsize / batch_size) + 1; ++step) {
       scheduler.epoch_begin(epoch);
       const auto &indices = scheduler.on_schedule(step);
 

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -12,24 +12,95 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "scheduler/scheduler.h"
+#include "flatflow/scheduler/scheduler.h"
 
 #include <cstdlib>
 #include <ctime>
 #include <map>
 #include <vector>
 
-#include "absl/container/inlined_vector.h"
+#include "absl/log/log.h"
+#include <absl/strings/str_join.h> // Add
+#include <absl/strings/str_format.h> // Add
 #include "flatbuffers/flatbuffers.h"
 #include "gtest/gtest.h"
 
+#include "flatflow/data/dataset_test.h"
+
 namespace {
-    class SchedulerTest final : private flatflow::Scheduler {
-    };
-    TEST(SchedulerTest, StaticSheduler){
+class SchedulerTest final
+    : private flatflow::scheduler::Scheduler<uint64_t, uint16_t> {
+ public:
+  inline SchedulerTest(const flatbuffers::Vector64<uint16_t> *sizes,
+                                uint64_t world_size, uint64_t batch_size, uint64_t seed)
+      : flatflow::scheduler::Scheduler<uint64_t, uint16_t>(
+            sizes, world_size, batch_size, seed) {}
+  inline auto on_schedule(uint64_t interval){
+    return schedule(interval);
+  }
+  inline void epoch_end(uint64_t epoch, uint64_t rank){
+    on_epoch_begin(epoch,rank);
+  }
+  inline void train_end(){
+    on_train_end();
+  }
+};
 
-    }
-    TEST(SchedulerTest, StaticSchedulerRemainder){
+TEST(SchedulerTest, StaticSchedule) {
+  std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
+  auto datasetsize = 1 << 10;
+  const auto world_size = 1 << 2;
+  auto batch_size = 1 << 5;
+  auto seed = 0UL;
+
+  auto items = std::map<uint16_t, std::size_t>();
+  for (uint16_t size = 1; size <= datasetsize; ++size) {
+    items.emplace(size, static_cast<std::size_t>(std::rand() % (datasetsize)));
+  }
+
+  auto sizes = std::vector<uint16_t>();
+  for (const auto item : items) {
+    const auto size = item.first;
+    auto count = item.second;
+    for (; 0 < count; --count) {
+      sizes.push_back(size);
     }
+  }
+  sizes.shrink_to_fit();
+
+  // As of FlatBuffers v24.3.7, it is not possible to initialize a 64-bit
+  // vector directly; use generated code from the FlatBuffers schema.
+  auto builder = flatbuffers::FlatBufferBuilder64();
+  auto sizes__ = builder.CreateVector64(sizes);
+  auto offset = CreateSizes(builder, sizes__);
+  builder.Finish(offset);
+  auto sizes_ = GetSizes(builder.GetBufferPointer());
+  // auto dataset = flatflow::data::Dataset(sizes_->sizes(), seed);
+
+  auto scheduler = SchedulerTest(sizes_->sizes(), world_size, batch_size, seed);
+  LOG(INFO) << "New version ";
+  for (auto epoch = 0; epoch < 10; ++epoch) {
+    for (auto rank = 0; rank < world_size; ++rank) {
+      scheduler.epoch_end(epoch, rank);
+    }
+    for (auto step = 0; step < datasetsize / batch_size; ++step) {
+      const auto& indices = scheduler.on_schedule(step);
+
+      std::vector<uint64_t> sums;
+      LOG(INFO) << "Calculating sums for step " << step << ": ";
+      for (auto& indice : indices) {
+          auto value = 0;
+          for (const auto index : indice) {
+              value += sizes_->sizes()->Get(index);
+          }
+          sums.push_back(value);
+      }
+
+      std::string vector_str = absl::StrJoin(sums, ", ");
+      LOG(INFO) << " step : " << step << "\t got : [" << vector_str << "]\n";
+    }
+  }
+  scheduler.train_end();
 }
+}  // namespace

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -48,10 +48,10 @@ class SchedulerTest final
 TEST(SchedulerTest, StaticScheduler) {
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
-  auto dataset_size = 1 << 10;
+  const auto dataset_size = 1 << 10;
   const auto world_size = 1 << 2;
-  auto batch_size = 1 << 5;
-  auto seed = 0UL;
+  const auto batch_size = 1 << 5;
+  const auto seed = 0UL;
 
   auto items = std::map<uint16_t, std::size_t>();
   for (uint16_t size = 1; size <= dataset_size; ++size) {

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -20,8 +20,8 @@
 #include <vector>
 
 #include "absl/log/log.h"
-#include <absl/strings/str_join.h> // Add
-#include <absl/strings/str_format.h> // Add
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
 #include "flatbuffers/flatbuffers.h"
 #include "gtest/gtest.h"
 
@@ -32,30 +32,16 @@ class SchedulerTest final
     : private flatflow::scheduler::Scheduler<uint64_t, uint16_t> {
  public:
   inline SchedulerTest(const flatbuffers::Vector64<uint16_t> *sizes,
-                                uint64_t world_size, uint64_t batch_size, uint64_t seed)
-      : flatflow::scheduler::Scheduler<uint64_t, uint16_t>(
-            sizes, world_size, batch_size, seed) {}
-  inline auto on_schedule(uint64_t interval){
-    return schedule(interval);
-  }
-  inline void batch_begin(uint64_t batch){
-    on_batch_begin(batch);
-  }
-  inline void batch_end(uint64_t batch){
-    on_batch_end(batch);
-  }
-  inline void epoch_end(uint64_t epoch){
-    on_epoch_end(epoch,0);
-  }
-  inline void epoch_begin(uint64_t epoch){
-    on_epoch_begin(epoch,0);
-  }
-  inline void train_begin(){
-    on_train_begin();
-  }
-  inline void train_end(){
-    on_train_end();
-  }
+                       uint64_t world_size, uint64_t batch_size, uint64_t seed)
+      : flatflow::scheduler::Scheduler<uint64_t, uint16_t>(sizes, world_size,
+                                                           batch_size, seed) {}
+  inline auto on_schedule(uint64_t interval) { return schedule(interval); }
+  inline void batch_begin(uint64_t batch) { on_batch_begin(batch); }
+  inline void batch_end(uint64_t batch) { on_batch_end(batch); }
+  inline void epoch_end(uint64_t epoch) { on_epoch_end(epoch, 0); }
+  inline void epoch_begin(uint64_t epoch) { on_epoch_begin(epoch, 0); }
+  inline void train_begin() { on_train_begin(); }
+  inline void train_end() { on_train_end(); }
 };
 
 TEST(SchedulerTest, StaticScheduler) {
@@ -80,7 +66,6 @@ TEST(SchedulerTest, StaticScheduler) {
     }
   }
   sizes.shrink_to_fit();
-  LOG(INFO) << "sizes111: " << sizes.size() << " items\n";
   // As of FlatBuffers v24.3.7, it is not possible to initialize a 64-bit
   // vector directly; use generated code from the FlatBuffers schema.
   auto builder = flatbuffers::FlatBufferBuilder64();
@@ -92,19 +77,17 @@ TEST(SchedulerTest, StaticScheduler) {
   auto scheduler = SchedulerTest(sizes_->sizes(), world_size, batch_size, seed);
   scheduler.train_begin();
   for (auto epoch = 0; epoch < 10; ++epoch) {
-
     for (auto step = 0; step < datasetsize / batch_size; ++step) {
       scheduler.epoch_begin(epoch);
-      const auto& indices = scheduler.on_schedule(step);
+      const auto &indices = scheduler.on_schedule(step);
 
       std::vector<uint64_t> sums;
-      for (auto& indice : indices) {
-          // LOG(INFO) << "indices " << indice.size() << ": ";
-          auto value = 0;
-          for (const auto index : indice) {
-              value += sizes_->sizes()->Get(index);
-          }
-          sums.push_back(value);
+      for (auto &indice : indices) {
+        auto value = 0;
+        for (const auto index : indice) {
+          value += sizes_->sizes()->Get(index);
+        }
+        sums.push_back(value);
       }
 
       std::string vector_str = absl::StrJoin(sums, ", ");
@@ -137,7 +120,6 @@ TEST(SchedulerTest, StaticSchedulerWithRemainder) {
     }
   }
   sizes.shrink_to_fit();
-  LOG(INFO) << "sizes: " << sizes.size() << " items\n";
   // As of FlatBuffers v24.3.7, it is not possible to initialize a 64-bit
   // vector directly; use generated code from the FlatBuffers schema.
   auto builder = flatbuffers::FlatBufferBuilder64();
@@ -149,19 +131,17 @@ TEST(SchedulerTest, StaticSchedulerWithRemainder) {
   auto scheduler = SchedulerTest(sizes_->sizes(), world_size, batch_size, seed);
   scheduler.train_begin();
   for (auto epoch = 0; epoch < 10; ++epoch) {
-
     for (auto step = 0; step < datasetsize / batch_size + 1; ++step) {
       scheduler.epoch_begin(epoch);
-      const auto& indices = scheduler.on_schedule(step);
+      const auto &indices = scheduler.on_schedule(step);
 
       std::vector<uint64_t> sums;
-      for (auto& indice : indices) {
-          // LOG(INFO) << "indices " << indice.size() << ": ";
-          auto value = 0;
-          for (const auto index : indice) {
-              value += sizes_->sizes()->Get(index);
-          }
-          sums.push_back(value);
+      for (auto &indice : indices) {
+        auto value = 0;
+        for (const auto index : indice) {
+          value += sizes_->sizes()->Get(index);
+        }
+        sums.push_back(value);
       }
 
       std::string vector_str = absl::StrJoin(sums, ", ");

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -28,6 +28,7 @@
 #include "flatflow/data/dataset_test.h"
 
 namespace {
+
 class SchedulerTest final
     : private flatflow::scheduler::Scheduler<uint64_t, uint16_t> {
  public:
@@ -47,13 +48,13 @@ class SchedulerTest final
 TEST(SchedulerTest, StaticScheduler) {
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
-  auto datasetsize = 1 << 10;
+  auto dataset_size = 1 << 10;
   const auto world_size = 1 << 2;
   auto batch_size = 1 << 5;
   auto seed = 0UL;
 
   auto items = std::map<uint16_t, std::size_t>();
-  for (uint16_t size = 1; size <= datasetsize; ++size) {
+  for (uint16_t size = 1; size <= dataset_size; ++size) {
     items.emplace(size, static_cast<std::size_t>(1));
   }
 
@@ -77,7 +78,7 @@ TEST(SchedulerTest, StaticScheduler) {
   auto scheduler = SchedulerTest(sizes_->sizes(), world_size, batch_size, seed);
   scheduler.train_begin();
   for (auto epoch = 0; epoch < 10; ++epoch) {
-    for (auto step = 0; step < datasetsize / batch_size; ++step) {
+    for (auto step = 0; step < dataset_size / batch_size; ++step) {
       scheduler.epoch_begin(epoch);
       const auto &indices = scheduler.on_schedule(step);
 
@@ -101,13 +102,13 @@ TEST(SchedulerTest, StaticScheduler) {
 TEST(SchedulerTest, StaticSchedulerWithRemainder) {
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
-  const auto datasetsize = (1 << 10) + (1 << 3);
+  const auto dataset_size = (1 << 10) + (1 << 3);
   const auto world_size = 1 << 2;
   const auto batch_size = 1 << 5;
   const auto seed = 0UL;
 
   auto items = std::map<uint16_t, std::size_t>();
-  for (uint16_t size = 1; size <= datasetsize; ++size) {
+  for (uint16_t size = 1; size <= dataset_size; ++size) {
     items.emplace(size, static_cast<std::size_t>(1));
   }
 
@@ -131,7 +132,7 @@ TEST(SchedulerTest, StaticSchedulerWithRemainder) {
   auto scheduler = SchedulerTest(sizes_->sizes(), world_size, batch_size, seed);
   scheduler.train_begin();
   for (auto epoch = 0; epoch < 10; ++epoch) {
-    for (auto step = 0; step < (datasetsize / batch_size) + 1; ++step) {
+    for (auto step = 0; step < (dataset_size / batch_size) + 1; ++step) {
       scheduler.epoch_begin(epoch);
       const auto &indices = scheduler.on_schedule(step);
 
@@ -151,4 +152,5 @@ TEST(SchedulerTest, StaticSchedulerWithRemainder) {
   }
   scheduler.train_end();
 }
+
 }  // namespace

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -54,7 +54,6 @@ TEST(SchedulerTest, StaticScheduler) {
 
   auto items = std::map<uint16_t, std::size_t>();
   for (uint16_t size = 1; size <= datasetsize; ++size) {
-    // items.emplace(size, static_cast<std::size_t>(std::rand() % (datasetsize)));
     items.emplace(size, static_cast<std::size_t>(1));
   }
 
@@ -109,7 +108,6 @@ TEST(SchedulerTest, StaticSchedulerWithRemainder) {
 
   auto items = std::map<uint16_t, std::size_t>();
   for (uint16_t size = 1; size <= datasetsize; ++size) {
-    // items.emplace(size, static_cast<std::size_t>(std::rand() % (datasetsize)));
     items.emplace(size, static_cast<std::size_t>(1));
   }
 

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -25,25 +25,6 @@
 
 namespace {
     class SchedulerTest final : private flatflow::Scheduler {
-      public:
-        SchedulerTest() = default;
-        ~SchedulerTest() = default;
-
-        void Test() {
-            std::srand(std::time(nullptr));
-            std::map<int, int> task_map;
-            for (int i = 0; i < 100; i++) {
-                task_map[i] = std::rand() % 100;
-            }
-            std::vector<int> task_list;
-            for (const auto& task : task_map) {
-                task_list.push_back(task.first);
-            }
-            std::vector<int> result = Schedule(task_list);
-            for (int i = 0; i < 100; i++) {
-                EXPECT_EQ(task_map[result[i]], task_map[result[i]]);
-            }
-        }
     };
     TEST(SchedulerTest, StaticSheduler){
 

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -1,0 +1,54 @@
+// Copyright 2024 The FlatFlow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "scheduler/scheduler.h"
+
+#include <cstdlib>
+#include <ctime>
+#include <map>
+#include <vector>
+
+#include "absl/container/inlined_vector.h"
+#include "flatbuffers/flatbuffers.h"
+#include "gtest/gtest.h"
+
+namespace {
+    class SchedulerTest final : private flatflow::Scheduler {
+      public:
+        SchedulerTest() = default;
+        ~SchedulerTest() = default;
+
+        void Test() {
+            std::srand(std::time(nullptr));
+            std::map<int, int> task_map;
+            for (int i = 0; i < 100; i++) {
+                task_map[i] = std::rand() % 100;
+            }
+            std::vector<int> task_list;
+            for (const auto& task : task_map) {
+                task_list.push_back(task.first);
+            }
+            std::vector<int> result = Schedule(task_list);
+            for (int i = 0; i < 100; i++) {
+                EXPECT_EQ(task_map[result[i]], task_map[result[i]]);
+            }
+        }
+    };
+    TEST(SchedulerTest, StaticSheduler){
+
+    }
+    TEST(SchedulerTest, StaticSchedulerRemainder){
+
+    }
+}

--- a/flatflow/scheduler/scheduler_test.cc
+++ b/flatflow/scheduler/scheduler_test.cc
@@ -101,10 +101,10 @@ TEST(SchedulerTest, StaticScheduler) {
 TEST(SchedulerTest, StaticSchedulerWithRemainder) {
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
-  auto datasetsize = (1 << 10) + (1 << 3);
+  const auto datasetsize = (1 << 10) + (1 << 3);
   const auto world_size = 1 << 2;
-  auto batch_size = 1 << 5;
-  auto seed = 0UL;
+  const auto batch_size = 1 << 5;
+  const auto seed = 0UL;
 
   auto items = std::map<uint16_t, std::size_t>();
   for (uint16_t size = 1; size <= datasetsize; ++size) {


### PR DESCRIPTION
This PR adds unit test  for static scheduler.
Output using ``make test`` :
```
Internal ctest changing into directory: /home/flatflow/build
Test project /home/flatflow/build
    Start 1: example
1/6 Test #1: example ......................................   Passed    0.00 sec
    Start 2: DatasetTest.Constructor
2/6 Test #2: DatasetTest.Constructor ......................   Passed    1.05 sec
    Start 3: DatasetTest.IntraBatchShuffling
3/6 Test #3: DatasetTest.IntraBatchShuffling ..............   Passed    8.74 sec
    Start 4: DatasetTest.IndexRetriever
4/6 Test #4: DatasetTest.IndexRetriever ...................   Passed    0.00 sec
    Start 5: SchedulerTest.StaticScheduler
5/6 Test #5: SchedulerTest.StaticScheduler ................   Passed    0.10 sec
    Start 6: SchedulerTest.StaticSchedulerWithRemainder
6/6 Test #6: SchedulerTest.StaticSchedulerWithRemainder ...   Passed    0.10 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =  10.03 sec
```
Test log : 
```
5/6 Testing: SchedulerTest.StaticScheduler
5/6 Test: SchedulerTest.StaticScheduler
Command: "/home/flatflow/build/flatflow/scheduler/scheduler_test" "--gtest_filter=SchedulerTest.StaticScheduler"
Directory: /home/flatflow/build/flatflow/scheduler
"SchedulerTest.StaticScheduler" start time: Apr 06 11:11 UTC
Output:
----------------------------------------------------------
Running main() from /home/flatflow/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = SchedulerTest.StaticScheduler
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SchedulerTest
[ RUN      ] SchedulerTest.StaticScheduler
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1712401872.241001      54 scheduler_test.cc:77]  datasetsize : 1024	batch_size : 32

I0000 00:00:1712401872.242064      54 dataset.h:134] Construction of inverted index took 0.000541 seconds
I0000 00:00:1712401872.242133      54 dataset.h:301] Epoch: 0 intra-batch shuffling took 0.000009 seconds
I0000 00:00:1712401872.242276      54 scheduler.h:120] Scheduling 32 steps took 0.000130 seconds
I0000 00:00:1712401872.242283      54 scheduler_test.cc:95]  step : 0	 got : [133107, 132639, 130447, 128607]
...

I0000 00:00:1712401872.342364      54 dataset.h:301] Epoch: 9 intra-batch shuffling took 0.000122 seconds
I0000 00:00:1712401872.342552      54 scheduler.h:120] Scheduling 32 steps took 0.000180 seconds
I0000 00:00:1712401872.342558      54 scheduler_test.cc:95]  step : 31	 got : [133107, 132639, 130447, 128607]

[       OK ] SchedulerTest.StaticScheduler (101 ms)
[----------] 1 test from SchedulerTest (101 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (101 ms total)
[  PASSED  ] 1 test.
<end of output>
Test time =   0.10 sec
----------------------------------------------------------
Test Passed.
"SchedulerTest.StaticScheduler" end time: Apr 06 11:11 UTC
"SchedulerTest.StaticScheduler" time elapsed: 00:00:00
----------------------------------------------------------

6/6 Testing: SchedulerTest.StaticSchedulerWithRemainder
6/6 Test: SchedulerTest.StaticSchedulerWithRemainder
Command: "/home/flatflow/build/flatflow/scheduler/scheduler_test" "--gtest_filter=SchedulerTest.StaticSchedulerWithRemainder"
Directory: /home/flatflow/build/flatflow/scheduler
"SchedulerTest.StaticSchedulerWithRemainder" start time: Apr 06 11:11 UTC
Output:
----------------------------------------------------------
Running main() from /home/flatflow/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = SchedulerTest.StaticSchedulerWithRemainder
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SchedulerTest
[ RUN      ] SchedulerTest.StaticSchedulerWithRemainder
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1712401872.346298      62 scheduler_test.cc:132]  datasetsize : 1032	batch_size : 32

I0000 00:00:1712401872.347211      62 dataset.h:134] Construction of inverted index took 0.000528 seconds
I0000 00:00:1712401872.347298      62 dataset.h:301] Epoch: 0 intra-batch shuffling took 0.000011 seconds
I0000 00:00:1712401872.347506      62 scheduler.h:120] Scheduling 33 steps took 0.000191 seconds
I0000 00:00:1712401872.347513      62 scheduler_test.cc:150]  step : 0	 got : [135796, 133438, 132421, 131373]

I0000 00:00:1712401872.347519      62 dataset.h:301] Epoch: 0 intra-batch shuffling took 0.000004 seconds
I0000 00:00:1712401872.347635      62 scheduler.h:120] Scheduling 33 steps took 0.000115 seconds
I0000 00:00:1712401872.347642      62 scheduler_test.cc:150]  step : 1	 got : [135796, 133438, 132421, 131373]
...

I0000 00:00:1712401872.442344      62 dataset.h:301] Epoch: 9 intra-batch shuffling took 0.000057 seconds
I0000 00:00:1712401872.442559      62 scheduler.h:120] Scheduling 33 steps took 0.000216 seconds
I0000 00:00:1712401872.442574      62 scheduler_test.cc:150]  step : 32	 got : [135796, 133438, 132421, 131373]

[       OK ] SchedulerTest.StaticSchedulerWithRemainder (96 ms)
[----------] 1 test from SchedulerTest (96 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (96 ms total)
[  PASSED  ] 1 test.
<end of output>
Test time =   0.10 sec
----------------------------------------------------------
Test Passed.
"SchedulerTest.StaticSchedulerWithRemainder" end time: Apr 06 11:11 UTC
"SchedulerTest.StaticSchedulerWithRemainder" time elapsed: 00:00:00
----------------------------------------------------------

End testing: Apr 06 11:11 UTC
```