### PR TITLE
data: fix log warning

### DIFF
--- a/flatflow/data/CMakeLists.txt
+++ b/flatflow/data/CMakeLists.txt
@@ -24,6 +24,7 @@ if(BUILD_TESTING)
     PRIVATE absl::btree
     PRIVATE absl::inlined_vector
     PRIVATE absl::log
+    PRIVATE absl::log_initialize
     PRIVATE absl::str_format
     PRIVATE flatbuffers
     PRIVATE GTest::gtest_main

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -21,6 +21,9 @@
 #include <utility>
 #include <vector>
 
+#include "absl/base/log_severity.h"
+#include "absl/log/globals.h"
+#include "absl/log/initialize.h"
 #include "flatbuffers/flatbuffers.h"
 #include "gtest/gtest.h"
 
@@ -72,6 +75,9 @@ class Dataset : public flatflow::data::Dataset<uint64_t, uint16_t> {
 class DatasetTest : public testing::Test {
  protected:
   void SetUp() override {
+    absl::InitializeLog();
+    absl::SetStderrThreshold(absl::LogSeverity::kInfo);
+
     constexpr auto kMaxSize = static_cast<uint16_t>(1 << 12);
     constexpr auto kMaxCount = static_cast<std::size_t>(1 << 15);
 


### PR DESCRIPTION
This PR enables not to show warning log in unit test.
Test log comparison is as below.
Previous Find Unit test Result:
```
4/4 Testing: DatasetTest.Find
4/4 Test: DatasetTest.Find
Command: "/home/flatflow/build/flatflow/data/dataset_test" "--gtest_filter=DatasetTest.Find"
Directory: /home/flatflow/build/flatflow/data
"DatasetTest.Find" start time: Apr 12 01:57 UTC
Output:
----------------------------------------------------------
Running main() from /home/flatflow/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = DatasetTest.Find
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DatasetTest
[ RUN      ] DatasetTest.Find
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1712887042.598281   34826 dataset.h:129] Construction of inverted index took 0.464789 seconds
I0000 00:00:1712887047.828435   34826 dataset.h:251] Epoch: 719263381 intra-batch shuffling took 3.945537 seconds
[       OK ] DatasetTest.Find (7141 ms)
[----------] 1 test from DatasetTest (7141 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (7141 ms total)
[  PASSED  ] 1 test.
<end of output>
Test time =   7.16 sec
----------------------------------------------------------
Test Passed.
"DatasetTest.Find" end time: Apr 12 01:57 UTC
"DatasetTest.Find" time elapsed: 00:00:07
----------------------------------------------------------

End testing: Apr 12 01:57 UTC
```
Fixed Find Unit test result: 
```
4/4 Testing: DatasetTest.Find
4/4 Test: DatasetTest.Find
Command: "/home/flatflow/build/flatflow/data/dataset_test" "--gtest_filter=DatasetTest.Find"
Directory: /home/flatflow/build/flatflow/data
"DatasetTest.Find" start time: Apr 12 01:36 UTC
Output:
----------------------------------------------------------
Running main() from /home/flatflow/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = DatasetTest.Find
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DatasetTest
[ RUN      ] DatasetTest.Find
I0412 01:36:48.899782   15145 dataset.h:129] Construction of inverted index took 0.442874 seconds
I0412 01:36:54.229830   15145 dataset.h:251] Epoch: 423148053 intra-batch shuffling took 3.886769 seconds
[       OK ] DatasetTest.Find (7186 ms)
[----------] 1 test from DatasetTest (7186 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (7186 ms total)
[  PASSED  ] 1 test.
<end of output>
Test time =   7.20 sec
----------------------------------------------------------
Test Passed.
"DatasetTest.Find" end time: Apr 12 01:36 UTC
"DatasetTest.Find" time elapsed: 00:00:07
----------------------------------------------------------

End testing: Apr 12 01:36 UTC
```