### PR TITLE
data: fix aborted test

### DIFF
--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -78,14 +78,11 @@ class DatasetTest : public testing::Test {
   void SetUp() override {
     if (!absl::log_internal::IsInitialized()) {
       absl::InitializeLog();
+      absl::SetStderrThreshold(absl::LogSeverity::kInfo);
     }
-    absl::SetStderrThreshold(absl::LogSeverity::kInfo);
 
     constexpr auto kMaxSize = static_cast<uint16_t>(1 << 12);
     constexpr auto kMaxCount = static_cast<std::size_t>(1 << 15);
-
-    absl::InitializeLog();
-    absl::SetStderrThreshold(absl::LogSeverity::kInfo);
 
     std::srand(static_cast<unsigned int>(std::time(nullptr)));
 

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -76,13 +76,13 @@ class Dataset : public flatflow::data::Dataset<uint64_t, uint16_t> {
 class DatasetTest : public testing::Test {
  protected:
   void SetUp() override {
+    constexpr auto kMaxSize = static_cast<uint16_t>(1 << 12);
+    constexpr auto kMaxCount = static_cast<std::size_t>(1 << 15);
+
     if (!absl::log_internal::IsInitialized()) {
       absl::InitializeLog();
       absl::SetStderrThreshold(absl::LogSeverity::kInfo);
     }
-
-    constexpr auto kMaxSize = static_cast<uint16_t>(1 << 12);
-    constexpr auto kMaxCount = static_cast<std::size_t>(1 << 15);
 
     std::srand(static_cast<unsigned int>(std::time(nullptr)));
 

--- a/flatflow/data/dataset_test.cc
+++ b/flatflow/data/dataset_test.cc
@@ -24,6 +24,7 @@
 #include "absl/base/log_severity.h"
 #include "absl/log/globals.h"
 #include "absl/log/initialize.h"
+#include "absl/log/internal/globals.h"
 #include "flatbuffers/flatbuffers.h"
 #include "gtest/gtest.h"
 
@@ -75,6 +76,11 @@ class Dataset : public flatflow::data::Dataset<uint64_t, uint16_t> {
 class DatasetTest : public testing::Test {
  protected:
   void SetUp() override {
+    if (!absl::log_internal::IsInitialized()) {
+      absl::InitializeLog();
+    }
+    absl::SetStderrThreshold(absl::LogSeverity::kInfo);
+
     constexpr auto kMaxSize = static_cast<uint16_t>(1 << 12);
     constexpr auto kMaxCount = static_cast<std::size_t>(1 << 15);
 


### PR DESCRIPTION
This PR resolves aborted test error when binary test is in run. 
Test log:
```
./build/flatflow/data/dataset_test 
Running main() from /home/flatflow/third_party/googletest/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from DatasetTest
[ RUN      ] DatasetTest.Constructor
I0415 02:53:00.609706    4661 dataset.h:129] Construction of inverted index took 0.647899 seconds
[       OK ] DatasetTest.Constructor (909 ms)
[ RUN      ] DatasetTest.IntraBatchShuffling
I0415 02:53:01.187662    4661 dataset.h:129] Construction of inverted index took 0.367063 seconds
I0415 02:53:08.999630    4661 dataset.h:251] Epoch: 384918267 intra-batch shuffling took 3.932174 seconds
[       OK ] DatasetTest.IntraBatchShuffling (8410 ms)
[ RUN      ] DatasetTest.Find
I0415 02:53:09.617010    4661 dataset.h:129] Construction of inverted index took 0.385385 seconds
I0415 02:53:14.775659    4661 dataset.h:251] Epoch: 1114878495 intra-batch shuffling took 3.876834 seconds
[       OK ] DatasetTest.Find (6965 ms)
[----------] 3 tests from DatasetTest (16284 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (16284 ms total)
[  PASSED  ] 3 tests.
```