### PR TITLE
megatron: support get_model_parallel_src_rank

### DIFF
--- a/flatflow/megatron/core/__init__.py
+++ b/flatflow/megatron/core/__init__.py
@@ -1,6 +1,4 @@
-from flatflow.megatron.core.parallel_state import (
-    get_model_parallel_src_rank
-)
+from flatflow.megatron.core.parallel_state import get_model_parallel_src_rank
 
 __all__ = [
     "get_model_parallel_src_rank",

--- a/flatflow/megatron/core/__init__.py
+++ b/flatflow/megatron/core/__init__.py
@@ -1,0 +1,7 @@
+from flatflow.megatron.core.parallel_state import (
+    get_model_parallel_src_rank
+)
+
+__all__ = [
+    "get_model_parallel_src_rank",
+]

--- a/flatflow/megatron/core/parallel_state.py
+++ b/flatflow/megatron/core/parallel_state.py
@@ -1,0 +1,16 @@
+import numpy as np
+import torch
+from megatron.core import parallel_state
+
+
+def get_model_parallel_src_rank() -> int:
+      r"""Calculate the global rank corresponding to the first local rank
+      in the model parallel group.
+      """
+      world_size = torch.distributed.get_world_size()
+      total_rank = np.arange(world_size)
+      pipeline_parallel_size = parallel_state.get_pipeline_model_parallel_world_size()
+      tensor_parallel_size = parallel_state.get_tensor_model_parallel_world_size()
+      total_rank = total_rank.reshape(pipeline_parallel_size, -1, tensor_parallel_size)
+      data_parallel_rank = parallel_state.get_data_parallel_rank()
+      return total_rank[:, data_parallel_rank, :].min()

--- a/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -173,7 +173,7 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
     def __iter__(self):
         indices = []
         model_group = parallel_state.get_model_parallel_group()
-        model_src_rank = parallel_state.get_model_parallel_src_rank()
+        model_src_rank = self.get_model_parallel_src_rank()
 
         while True:
             if self.consumed_samples > self.total_length // self.num_data_parallel_group:

--- a/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -149,16 +149,17 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
             )
 
     @staticmethod
-    def get_model_parallel_src_rank():
-        """Calculate the global rank corresponding to the first local rank
-        in the model parallel group."""
+    def get_model_parallel_src_rank() -> int:
+        r"""Calculate the global rank corresponding to the first local rank
+        in the model parallel group.
+        """
         world_size = torch.distributed.get_world_size()
-        all_ranks = np.arange(world_size)
-        tp_size = parallel_state.get_tensor_model_parallel_world_size()
-        pp_size = parallel_state.get_pipeline_model_parallel_world_size()
-        all_ranks = all_ranks.reshape(pp_size, -1, tp_size)
-        dp_rank = parallel_state.get_data_parallel_rank()
-        return all_ranks[:, dp_rank, :].min()
+        total_rank = np.arange(world_size)
+        pipeline_parallel_size = parallel_state.get_pipeline_model_parallel_world_size()
+        tensor_parallel_size = parallel_state.get_tensor_model_parallel_world_size()
+        total_rank = total_rank.reshape(pipeline_parallel_size, -1, tensor_parallel_size)
+        data_parallel_rank = parallel_state.get_data_parallel_rank()
+        return total_rank[:, data_parallel_rank, :].min()
 
     def set_epoch(self, epoch: int) -> None:
         r"""Sets the epoch for this sampler. This ensures all replicas use a different random ordering for each epoch.


### PR DESCRIPTION
This PR adds `megatron_batch_samplers.py` a staticmethod `get_model_parallel_src_rank()`.

Currently retrieving **source rank** from model parallel group is not supported by `parallel_state`.

By implementing `get_model_parallel_src_rank()`, we can find the global rank corresponding to the source of local rank.
