### PR TITLE
megatron: enable interleaving schedule

### DIFF
--- a/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -165,7 +165,7 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
             indices_size = [0]
             if self.pipeline_parallel_rank == 0 and self.tensor_parallel_rank == 0:
                 if not self.converged:
-                self.costs = self.profiler.extract() if self.profiler.event.is_set() else None
+                    self.costs = self.profiler.extract() if self.profiler.event.is_set() else None
                 response = self.client.Broadcast(epoch=self.epoch, costs=self.costs)
                 self.converged = response.Converged()
                 if self.converged:

--- a/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -165,12 +165,8 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
             indices_size = [0]
             if self.pipeline_parallel_rank == 0 and self.tensor_parallel_rank == 0:
                 if not self.converged:
-                    if self.profiler.event.is_set():
-                        self.costs = self.profiler.extract()
-                    else:
-                        self.costs = None
+                self.costs = self.profiler.extract() if self.profiler.event.is_set() else None
                 response = self.client.Broadcast(epoch=self.epoch, costs=self.costs)
-                self.costs = None
                 self.converged = response.Converged()
                 if self.converged:
                     for hook in self.profiler.hook_handles:

--- a/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -165,8 +165,10 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
             indices_size = [0]
             if self.pipeline_parallel_rank == 0 and self.tensor_parallel_rank == 0:
                 if not self.converged:
-                    self.profiler.wait()
-                    self.costs = self.profiler.extract()
+                    if self.profiler.event.is_set():
+                        self.costs = self.profiler.extract()
+                    else:
+                        self.costs = None
                 response = self.client.Broadcast(epoch=self.epoch, costs=self.costs)
                 self.costs = None
                 self.converged = response.Converged()

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -61,6 +61,7 @@ try:
     from megatron.core import parallel_state
     from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
     from megatron.core.utils import get_model_config
+
     HAVE_MEGATRON_CORE = True
 
 except (ImportError, ModuleNotFoundError):
@@ -423,7 +424,7 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
             module.config.param_sync_func = param_sync_func
 
         fwd_bwd_function = get_forward_backward_func()
-        # todo config 설정에 
+
         losses_reduced_per_micro_batch = fwd_bwd_function(
             forward_step_func=self.get_forward_output_and_loss_func(tuning=True, validation_step=forward_only),
             data_iterator=self._make_data_iterator_list(data_iter),

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -38,7 +38,6 @@ class ComputeProfiler:
         self.mp_src_rank = torch.distributed.get_process_group_ranks(self.mp_group)[0]
         self.pp_group = parallel_state.get_pipeline_model_parallel_group()
         self.event = mp.Event()
-        self.event.set()
 
     def _generate_batch_key(self, microbatch_id: int) -> str:
         return f"dp{parallel_state.get_data_parallel_rank()}_pp{parallel_state.get_pipeline_model_parallel_rank()}_tp{parallel_state.get_tensor_model_parallel_rank()}_batch{microbatch_id}"
@@ -109,6 +108,9 @@ class ComputeProfiler:
     def get_batch_id(self, key):
         match = re.search(r"batch(\d+)", key)
         return int(match.group(1)) if match else -1
+
+    def set_event(self):
+        self.event.set()
 
     def update(self, latest_microbatch_id: int):
         keys_to_remove = []


### PR DESCRIPTION
This PR fixes previous error of interleaving scheduling.
Previous version only supported non-interleaving scheduling.

In `megatron_batch_sampler.py,` multiprocessing event checking method is fixed. This is because we need to call sampler multiple times before the pipeline starts. **Interleaving schedule** has a constraint that _the number of microbatches should be divisible by `pipeline parallel world size`._ 

In `megatron_gpt_sft_model.py`, checking `virtual pipeline parallelism` is added while initializing. In order to do interleaving scheduling, we need to set `virtual pipeline parallelism` larger than 0. 

Also, we use `torch.distributed.get_rank()` rather than `Appstate.global_rank()`. This is because `Appstate.global_rank()` is not pointing to the exact gpu device rank number. 

In `profiler.py`, setting event to set is added to be called after the current pipeline stage becomes the last pipeline stage and ends.