### PR TITLE
profiler: fix profiling logic

### DIFF
--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -32,8 +32,8 @@ from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_sampler
 )
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
 from nemo.collections.nlp.modules.common.megatron.utils import (
-    get_iterator_k_split,
     average_losses_across_data_parallel_group,
+    get_iterator_k_split,
 )
 from nemo.collections.nlp.modules.common.text_generation_utils import generate, get_computeprob_response
 from nemo.collections.nlp.parts.mixins.nlp_adapter_mixins import NLPAdapterModelMixin
@@ -124,7 +124,7 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
             config = get_model_config(self.model)
             config.variable_seq_lengths = True
             self.variable_seq_lengths = True
-        
+
     def setup_metric(self, data_cfg):
         metric_name = "exact_string_match"
         if not hasattr(data_cfg, "metric"):
@@ -966,13 +966,13 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
             profiler.record_start(module, input)
         def forward_hook(module, input, output):
             profiler.record_end(module, input, output)
-        
+
         if isinstance(self.model, list):
             for model in self.model:
                 for _, module in model.named_modules():
                     pre_handle = module.register_forward_pre_hook(forward_pre_hook)
                     post_handle = module.register_forward_hook(forward_hook)
-                    profiler.hook_handles.extend([pre_handle, post_handle]) 
+                    profiler.hook_handles.extend([pre_handle, post_handle])
         else:
             for _, module in self.model.named_modules():
                 pre_handle = module.register_forward_pre_hook(forward_pre_hook)

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -1116,7 +1116,8 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
                         max_seqlen_kv=max_seqlen,
                         qkv_format='thd',
                     )
-
+            if profiler is not None and global_microbatch_id is not None:
+                profiler.set_microbatch_id(global_microbatch_id)
             output_tensor = model(**forward_args)
 
             def loss_func(output_tensor):

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -46,6 +46,9 @@ class ComputeProfiler:
         tensor_parallel_rank = parallel_state.get_tensor_model_parallel_rank()
         return f"dp{data_parallel_rank}_pp{pipeline_parallel_rank}_tp{tensor_parallel_rank}_batch{microbatch_id}"
 
+    def set_microbatch_id(self, microbatch_id: int):
+        self.current_batch_id = microbatch_id
+
     def update_microbatch_id(self):
         self.current_batch_id += 1
 
@@ -104,7 +107,7 @@ class ComputeProfiler:
                 value for _, value in sorted(processed_times.items(), key=lambda x: self.get_batch_id(x[0]))
             ]
 
-            self.forward_times = sorted_times
+            self.forward_times.extend(sorted_times)
             self.event.set()
 
         self.update(latest_microbatch_id[0])

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -73,7 +73,7 @@ class ComputeProfiler:
                 dict(dp1_pp0_tp0_batch0: 1.0, dp1_pp0_tp0_batch1: 2.0, ...),
                 ...
         """
-        if parallel_state.is_pipeline_last_stage():
+        if parallel_state.get_pipeline_model_parallel_rank() == self.last_stage_rank:
             latest_microbatch_id = [-1]
             for key in self.buffer.keys():
                 latest_microbatch_id[0] = max(latest_microbatch_id[0], int(key.split("batch")[1]))

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -156,8 +156,8 @@ class MemoryProfiler:
         tensor_parallel_rank = parallel_state.get_tensor_model_parallel_rank()
         return f"dp{data_parallel_rank}_pp{pipeline_parallel_rank}_tp{tensor_parallel_rank}_batch{microbatch_id}"
 
-    def update_microbatch_id(self):
-        self.current_batch_id += 1
+    def set_microbatch_id(self, microbatch_id: int):
+        self.current_batch_id = microbatch_id
 
     def record_start(self, module: Any, input: Any) -> None:
         batch_key = self._generate_batch_key(self.current_batch_id)


### PR DESCRIPTION
This PR updates several scripts, `profiler.py`, `megatron_gpt_sft_model.py`,` schedules.py`.
These scripts are updated in order to correctly profile of each microbatches.

In `profiler.py`, `set_microbatch_id` method is used instead of `update_microbatch_id`. This is because we need to consider interleaving 1F1B. 
For example model's layer 0 and 8 are placed at stage 0, so when we need the model to forward pass layer 8 we need to revisit stage 0 with the exact microbatch id.

Also, I've made implementation mistakes on `profiler.py`.
`self.forward_times` should store latest forward times in FIFO order using `extend`. 

In `megatron_gpt_sft_model.py`, `get_forward_output_and_loss_func` is added on this PR. 
`get_forward_output_and_loss_func` was declared at `megatron_gpt_model.py`, but in order to set microbatch before model forward pass, we need to declare `megatron_gpt_sft_model.py`'s own.

In `schedules.py`, `memory_profiler`, `compute_profiler`, and `global_microbatch_id` variables are added as function arguments. These three arguments are eventually used at calling `get_forward_output_and_loss_func` inside `forward_step` in `schedules.py`.