### PR TITLE
profiler: update profiling objective from PGO to forward/backward profile

### DIFF
--- a/flatflow/megatron/core/pipeline_parallel/schedules.py
+++ b/flatflow/megatron/core/pipeline_parallel/schedules.py
@@ -349,7 +349,7 @@ def forward_step(
     return [output_tensor], num_tokens
 
 
-def backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config):
+def backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config, compute_profiler=None, memory_profiler=None, global_microbatch_id=None):
     """Backward step through passed-in output tensor.
 
     If last stage, output_tensor_grad is None, otherwise gradient of loss
@@ -382,6 +382,10 @@ def backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, c
     # Backward pass.
     if output_tensor_grad[0] is None and config.grad_scale_func is not None:
         output_tensor[0] = config.grad_scale_func(output_tensor[0])
+    if compute_profiler is not None and global_microbatch_id is not None:
+        compute_profiler.set_microbatch_id(global_microbatch_id)
+    if memory_profiler is not None and global_microbatch_id is not None:
+        memory_profiler.set_microbatch_id(global_microbatch_id)
 
     if config.deallocate_pipeline_outputs:
         custom_backward(output_tensor[0], output_tensor_grad[0])
@@ -491,7 +495,7 @@ def forward_backward_no_pipelining(
             )
             total_num_tokens += num_tokens.item()
             if not forward_only:
-                backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config)
+                backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config, compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=i)
 
     # Run computation for last microbatch out of context handler (want to
     # synchronize gradients).
@@ -515,7 +519,7 @@ def forward_backward_no_pipelining(
     total_num_tokens += num_tokens.item()
 
     if not forward_only:
-        backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config)
+        backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config,compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=num_microbatches - 1)
 
     if config.finalize_model_grads_func is not None and not forward_only:
         # Finalize model grads (perform full grad all-reduce / reduce-scatter for
@@ -823,7 +827,7 @@ def forward_backward_pipelining_with_interleaving(
 
         return output_tensor
 
-    def backward_step_helper(microbatch_id):
+    def backward_step_helper(microbatch_id, compute_profiler=None, memory_profiler=None, global_microbatch_id=None):
         """Helper method to run backward step with model split into chunks
         (run set_virtual_pipeline_model_parallel_rank() before calling
         backward_step())."""
@@ -842,7 +846,7 @@ def forward_backward_pipelining_with_interleaving(
         output_tensor = output_tensors[model_chunk_id].pop(0)
         output_tensor_grad = output_tensor_grads[model_chunk_id].pop(0)
         input_tensor_grad = backward_step(
-            input_tensor, output_tensor, output_tensor_grad, model_type, config
+            input_tensor, output_tensor, output_tensor_grad, model_type, config, compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=global_microbatch_id
         )
 
         # launch grad synchronization (custom grad sync)
@@ -1036,7 +1040,7 @@ def forward_backward_pipelining_with_interleaving(
 
             # Backward pass.
             backward_k = k
-            input_tensor_grad = backward_step_helper(backward_k)
+            input_tensor_grad = backward_step_helper(backward_k, compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=total_microbatch_id + current_microbatch)
 
             backward_model_chunk_id = get_model_chunk_id(backward_k, forward=False)
             parallel_state.set_virtual_pipeline_model_parallel_rank(backward_model_chunk_id)
@@ -1073,7 +1077,7 @@ def forward_backward_pipelining_with_interleaving(
 
             # Backward pass.
             backward_k = k
-            input_tensor_grad = backward_step_helper(backward_k)
+            input_tensor_grad = backward_step_helper(backward_k, compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=total_microbatch_id + current_microbatch)
 
             # Send output_tensor and input_tensor_grad, receive input_tensor
             # and output_tensor_grad.
@@ -1154,7 +1158,7 @@ def forward_backward_pipelining_with_interleaving(
                 p2p_communication.recv_backward(tensor_shape, config=config)
             )
         for k in range(num_microbatches_remaining, total_num_microbatches):
-            input_tensor_grad = backward_step_helper(k)
+            input_tensor_grad = backward_step_helper(backward_k, compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=total_microbatch_id + k)
             next_backward_model_chunk_id = get_model_chunk_id(k + 1, forward=False)
             recv_next = True
             if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
@@ -1537,7 +1541,7 @@ def forward_backward_pipelining_without_interleaving(
                     enable_grad_sync()
 
             input_tensor_grad = backward_step(
-                input_tensor, output_tensor, output_tensor_grad, model_type, config
+                input_tensor, output_tensor, output_tensor_grad, model_type, config, compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=total_microbatch_id + num_warmup_microbatches + i
             )
 
             if last_iteration:
@@ -1566,8 +1570,8 @@ def forward_backward_pipelining_without_interleaving(
 
             output_tensor_grad = recv_backward(send_tensor_shapes, config)
 
-            input_tensor_grad = backward_step(
-                input_tensor, output_tensor, output_tensor_grad, model_type, config
+            input_tensor_grad = backward_step( 
+                input_tensor, output_tensor, output_tensor_grad, model_type, config, compute_profiler=compute_profiler, memory_profiler=memory_profiler, global_microbatch_id=total_microbatch_id + num_microbatches_remaining + i
             )
 
             send_backward(input_tensor_grad, recv_tensor_shapes, config)

--- a/flatflow/megatron/core/pipeline_parallel/schedules.py
+++ b/flatflow/megatron/core/pipeline_parallel/schedules.py
@@ -464,6 +464,8 @@ def forward_backward_no_pipelining(
         data_iterator = data_iterator[0]
 
     config = get_model_config(model)
+    if compute_profiler is not None and memory_profiler is not None:
+        config.deallocate_pipeline_outputs = False
     if config.timers is not None:
         config.timers('forward-backward', log_level=1).start(barrier=config.barrier_with_L1_time)
 
@@ -602,6 +604,8 @@ def forward_backward_pipelining_with_interleaving(
 
     global total_microbatch_id
     config = get_model_config(model[0])
+    if compute_profiler is not None and memory_profiler is not None:
+        config.deallocate_pipeline_outputs = False
     if config.overlap_p2p_comm and config.batch_p2p_comm:
         raise ValueError("Can not use both overlap_p2p_comm and batch_p2p_comm")
 
@@ -1349,6 +1353,8 @@ def forward_backward_pipelining_without_interleaving(
         data_iterator = data_iterator[0]
 
     config = get_model_config(model)
+    if compute_profiler is not None and memory_profiler is not None:
+        config.deallocate_pipeline_outputs = False
     if config.overlap_p2p_comm:
         raise ValueError(
             "Non-interleaved pipeline parallelism does not support overlapping p2p communication"

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -456,10 +456,6 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
             memory_profiler=self.memory_profiler[self.profile_key] if self.use_memory_profile else None,
         )
 
-        if self.use_compute_profile:
-            self.compute_profiler[self.profile_key].event.set()
-            self.compute_profiler[self.profile_key].gather_times()
-
         non_loss_tensors = {}
         # only the last stages of the pipeline return losses
         if losses_reduced_per_micro_batch:

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -918,7 +918,6 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
                 drop_last=data_cfg.drop_last,
                 pad_samples_to_global_batch_size=not data_cfg.drop_last,
                 dataset=dataset,
-                profiler=self.compute_profiler[self.profile_key] if self.use_compute_profile else None,
             )
             data_loader_cls = flatflow.torch.utils.data.DataLoader
         else:

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -441,7 +441,7 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
             module.config.grad_sync_func = grad_sync_func
             module.config.param_sync_func = param_sync_func
 
-        fwd_bwd_function = flatflow.megatron.core.pipeline_parallel.schedules.get_forward_backward_func() if self.use_flatflow else get_forward_backward_func()
+        fwd_bwd_function = flatflow.megatron.core.pipeline_parallel.schedules.get_forward_backward_func()
 
         losses_reduced_per_micro_batch = fwd_bwd_function(
             forward_step_func=self.get_forward_output_and_loss_func(tuning=True, validation_step=forward_only),

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -116,15 +116,11 @@ class ComputeProfiler:
                 parallel_state.get_pipeline_model_parallel_world_size()
                 * parallel_state.get_tensor_model_parallel_world_size()
             )
-            num_groups = self.world_size // group_size
-
-            data_object = [None] * num_groups
         else:
             processed_data = None
-            data_object = None
 
-        if self.rank == 0:
-            data_object = [None] * self.world_size
+        # gather_object를 위한 리스트는 rank 0에서만 필요
+        data_object = [None] * self.world_size if self.rank == 0 else None
 
         torch.distributed.gather_object(obj=processed_data, object_gather_list=data_object, dst=0)
         if self.rank == 0:

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -119,7 +119,6 @@ class ComputeProfiler:
         else:
             processed_data = None
 
-        # gather_object를 위한 리스트는 rank 0에서만 필요
         data_object = [None] * self.world_size if self.rank == 0 else None
 
         torch.distributed.gather_object(obj=processed_data, object_gather_list=data_object, dst=0)

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -26,19 +26,103 @@ __all__ = ["ComputeProfiler", "MemoryProfiler"]
 
 
 class ComputeProfiler:
-    def __init__(self, rank, hook_handles=[]):
-        self.start_times = {}
+    def __init__(self, rank, layers, layer_events):
+        self.timestamp = {}
         self.forward_times = []
         self.buffer = defaultdict(float)
         self.rank = rank
         self.world_size = parallel_state.get_pipeline_model_parallel_world_size()
         self.current_batch_id = 0
-        self.hook_handles = hook_handles
+        self.hook_handles = []
         self.last_stage_rank = parallel_state.get_pipeline_model_parallel_last_rank()
         self.mp_group = parallel_state.get_model_parallel_group()
         self.mp_src_rank = torch.distributed.get_process_group_ranks(self.mp_group)[0]
         self.pp_group = parallel_state.get_pipeline_model_parallel_group()
         self.event = mp.Event()
+        self.layers = layers
+        self.layer_events = layer_events
+        self.times = defaultdict(float)
+        for name in self.layers.keys():
+            self.register_hooks(name)
+
+    def register_hooks(self, name):
+        events = self.layer_events[name]
+        layer = self.layers[name]
+
+        def forward_pre_hook(module, _):
+            batch_key = "forward_" + self._generate_batch_key(self.current_batch_id)
+            torch.cuda.synchronize()
+            events["forward_pre"].record()
+            self.timestamp[batch_key] = time.perf_counter()
+
+        def forward_hook(module, _, _1):
+            events["forward_post"].record()
+            batch_key = "forward_" + self._generate_batch_key(self.current_batch_id)
+            torch.cuda.synchronize()
+            self.times[batch_key] += events["forward_pre"].elapsed_time(events["forward_post"])
+
+        def backward_pre_hook(module, _):
+            batch_key = "backward_" + self._generate_batch_key(self.current_batch_id)
+            
+            torch.cuda.synchronize()
+            events["backward_pre"].record()
+            self.timestamp[batch_key] = time.perf_counter()
+
+        def backward_hook(module, _, _1):
+            events["backward_post"].record()
+            batch_key = "backward_" + self._generate_batch_key(self.current_batch_id)
+            torch.cuda.synchronize()
+            self.times[batch_key] += events["backward_pre"].elapsed_time(events["backward_post"])
+            
+
+        self.hook_handles.append(layer.register_forward_pre_hook(forward_pre_hook))
+        self.hook_handles.append(layer.register_forward_hook(forward_hook))
+
+        self.hook_handles.append(layer.register_full_backward_pre_hook(backward_pre_hook))
+        self.hook_handles.append(layer.register_full_backward_hook(backward_hook))
+
+    def save_latency_log(self):
+        compute_times = (
+            [None]
+            * parallel_state.get_pipeline_model_parallel_world_size()
+            * parallel_state.get_tensor_model_parallel_world_size()
+        )
+
+        torch.distributed.all_gather_object(compute_times, self.times, group=self.mp_group)
+
+        if self.rank == self.mp_src_rank:
+            tp_max_memory = defaultdict(float)
+            for data in compute_times:
+                if data:
+                    for key, value in data.items():
+                        base_key = re.sub(r"_tp_\d+", "", key)
+                        tp_max_memory[base_key] = max(tp_max_memory[base_key], value)
+
+            processed_memory = defaultdict(float)
+            for key, value in tp_max_memory.items():
+                base_key = re.sub(r"_pp\d+", "", key)
+                processed_memory[base_key] += value
+
+            group_size = (
+                parallel_state.get_pipeline_model_parallel_world_size()
+                * parallel_state.get_tensor_model_parallel_world_size()
+            )
+            num_groups = self.world_size // group_size
+
+            memory_object = [None] * num_groups
+        else:
+            processed_memory = None
+            memory_object = None
+
+        if self.rank == 0:
+            memory_object = [None] * self.world_size
+
+        torch.distributed.gather_object(obj=processed_memory, object_gather_list=memory_object, dst=0)
+        if self.rank == 0:
+            assert memory_object is not None
+            revised = [memory for memory in memory_object if memory is not None]
+            with open("latecny_profile.json", "w") as f:
+                json.dump(revised, f, indent=4)
 
     def _generate_batch_key(self, microbatch_id: int) -> str:
         data_parallel_rank = parallel_state.get_data_parallel_rank()
@@ -141,17 +225,55 @@ class ComputeProfiler:
 
 
 class MemoryProfiler:
-    def __init__(self, rank, hook_handles=[]):
+    def __init__(self, rank, layers, layer_events):
         self.rank = rank
         self.world_size = parallel_state.get_pipeline_model_parallel_world_size()
         self.current_batch_id = 0
-        self.hook_handles = hook_handles
+        self.hook_handles = []
         self.last_stage_rank = parallel_state.get_pipeline_model_parallel_last_rank()
         self.mp_group = parallel_state.get_model_parallel_group()
         self.mp_src_rank = torch.distributed.get_process_group_ranks(self.mp_group)[0]
         self.pp_group = parallel_state.get_pipeline_model_parallel_group()
         self.memory_tracker = defaultdict(float)
         self.memory_buffer = {}
+        self.layers = layers
+        self.layer_events = layer_events
+        self.times = defaultdict(float)
+        for name in self.layers.keys():
+            self.register_hooks(name)
+
+    def register_hooks(self, name):
+        events = self.layer_events[name]
+        layer = self.layers[name]
+
+        def forward_pre_hook(module, _):
+            batch_key = "forward_" + self._generate_batch_key(self.current_batch_id)
+            self.memory_buffer[batch_key] = torch.cuda.memory_allocated() / 1024 / 1024
+
+        def forward_hook(module, _, _1):
+            batch_key = "forward_" + self._generate_batch_key(self.current_batch_id)
+            if batch_key in self.memory_buffer:
+                self.memory_tracker[batch_key] += (
+                    torch.cuda.memory_allocated() / 1024 / 1024 - self.memory_buffer[batch_key]
+                )
+
+        def backward_pre_hook(module, _):
+            batch_key = "backward_" + self._generate_batch_key(self.current_batch_id)
+            self.memory_buffer[batch_key] = torch.cuda.memory_allocated() / 1024 / 1024
+
+
+        def backward_hook(module, _, _1):
+            batch_key = "backward_" + self._generate_batch_key(self.current_batch_id)
+            if batch_key in self.memory_buffer:
+                self.memory_tracker[batch_key] += (
+                    torch.cuda.memory_allocated() / 1024 / 1024 - self.memory_buffer[batch_key]
+                )
+
+        self.hook_handles.append(layer.register_forward_pre_hook(forward_pre_hook))
+        self.hook_handles.append(layer.register_forward_hook(forward_hook))
+
+        self.hook_handles.append(layer.register_full_backward_pre_hook(backward_pre_hook))
+        self.hook_handles.append(layer.register_full_backward_hook(backward_hook))
 
     def _generate_batch_key(self, microbatch_id: int) -> str:
         data_parallel_rank = parallel_state.get_data_parallel_rank()

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -97,7 +97,7 @@ class ComputeProfiler:
         torch.distributed.all_gather_object(compute_times, combined_data, group=self.mp_group)
         if self.rank == self.mp_src_rank:
             elapsed = defaultdict(float)
-            initial_time = defaultdict(lambda: float('inf'))
+            initial_time = dict()
 
             for data in compute_times:
                 if data:
@@ -106,7 +106,8 @@ class ComputeProfiler:
                         elapsed[base_key] = max(elapsed[base_key], value)
                     for key, value in data['timestamps'].items():
                         base_key = re.sub(r"_tp_\d+", "", key)
-                        initial_time[base_key] = min(initial_time[base_key], value)
+                        if base_key not in initial_time or value < initial_time[base_key]:
+                            initial_time[base_key] = value
 
             processed_data = {
                 'timestamp': initial_time,

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -112,10 +112,7 @@ class ComputeProfiler:
                 'timestamp': initial_time,
                 'elapsed_time': elapsed
             }
-            group_size = (
-                parallel_state.get_pipeline_model_parallel_world_size()
-                * parallel_state.get_tensor_model_parallel_world_size()
-            )
+
         else:
             processed_data = None
 

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -85,7 +85,7 @@ class ComputeProfiler:
         
         combined_data = {
         'elapsed_time': self.times,
-        'timestamps': self.start_times
+        'timestamps': self.timestamp
         }
         
         compute_times = (

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -31,7 +31,7 @@ class ComputeProfiler:
         self.forward_times = []
         self.buffer = defaultdict(float)
         self.rank = rank
-        self.world_size = parallel_state.get_pipeline_model_parallel_world_size()
+        self.world_size = torch.distributed.get_world_size()
         self.current_batch_id = 0
         self.hook_handles = []
         self.last_stage_rank = parallel_state.get_pipeline_model_parallel_last_rank()
@@ -229,7 +229,7 @@ class ComputeProfiler:
 class MemoryProfiler:
     def __init__(self, rank, layers, layer_events):
         self.rank = rank
-        self.world_size = parallel_state.get_pipeline_model_parallel_world_size()
+        self.world_size = torch.distributed.get_world_size()
         self.current_batch_id = 0
         self.hook_handles = []
         self.last_stage_rank = parallel_state.get_pipeline_model_parallel_last_rank()

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -318,19 +318,10 @@ class MemoryProfiler:
                 base_key = re.sub(r"_pp\d+", "", key)
                 processed_memory[base_key] += value
 
-            group_size = (
-                parallel_state.get_pipeline_model_parallel_world_size()
-                * parallel_state.get_tensor_model_parallel_world_size()
-            )
-            num_groups = self.world_size // group_size
-
-            memory_object = [None] * num_groups
         else:
             processed_memory = None
-            memory_object = None
 
-        if self.rank == 0:
-            memory_object = [None] * self.world_size
+        memory_object = [None] * self.world_size if self.rank == 0 else None
 
         torch.distributed.gather_object(obj=processed_memory, object_gather_list=memory_object, dst=0)
         if self.rank == 0:


### PR DESCRIPTION
This PR brings several updates.
Mainly it enables us to use no PGO with profiler and profiles for forward/backward elapsed time.
Firstly, `torch.cuda.Event` is used to profile exact time. We also added backward hooks in `profiler.py`.
Second, we excluded profiler from `megatron_batch_samplers.py` since we don't need this logic anymore.
Third, we modified backward related functions at `schedules.py` to receive `compute_profiler` and `memory_profiler`.
Lastly in `megatron_gpt_sft_model.py`, we added to save log for compute_profiler. By this we can visualize bubble time for pipeline stages.
Also, we modified to generate `torch.cuda.Event` for each model layers so that `memory_profiler` and `compute_profiler` can utilize them.