### PR TITLE
core: configure use_bpipe option

### DIFF
--- a/examples/nemo/nlp/language_modeling/tuning/conf/megatron_gpt_finetuning_config.yaml
+++ b/examples/nemo/nlp/language_modeling/tuning/conf/megatron_gpt_finetuning_config.yaml
@@ -87,7 +87,8 @@ model:
 
   use_flatflow: False
   enable_profile: True
-
+  use_bpipe: False
+  
   peft:
     peft_scheme: "adapter"  # can be either "adapter", "ia3", or "ptuning"
     restore_from_path: null

--- a/examples/nemo/nlp/language_modeling/tuning/megatron_gpt_finetuning.py
+++ b/examples/nemo/nlp/language_modeling/tuning/megatron_gpt_finetuning.py
@@ -15,13 +15,13 @@
 # limitations under the License.
 
 import torch.multiprocessing as mp
-from nemo.collections.nlp.parts.megatron_trainer_builder import MegatronLMPPTrainerBuilder
 from nemo.collections.nlp.parts.peft_config import PEFT_CONFIG_MAP
 from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 from omegaconf import OmegaConf
 
+from flatflow.nemo.collections.nlp.parts.megatron_trainer_builder import MegatronLMPPTrainerBuilder
 from flatflow.nemo.collections.nlp.models.language_modeling import MegatronGPTSFTModel
 
 mp.set_start_method("spawn", force=True)

--- a/flatflow/megatron/core/bpipe/bpipe_state.py
+++ b/flatflow/megatron/core/bpipe/bpipe_state.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2025, The FlatFlow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# BPipe options
+_USE_BPIPE = False
+
+def is_bpipe_enabled():
+    """Return True if bpipe is enabled, False otherwise."""
+    return _USE_BPIPE
+
+# BPipe option
+def set_bpipe_option(enabled):
+    """Enable or disable bpipe."""
+    global _USE_BPIPE
+    _USE_BPIPE = enabled

--- a/flatflow/nemo/collections/nlp/parts/megatron_trainer_builder.py
+++ b/flatflow/nemo/collections/nlp/parts/megatron_trainer_builder.py
@@ -17,39 +17,31 @@
 import sys
 from typing import Optional, Union
 
-from lightning_fabric.utilities.exceptions import MisconfigurationException
 from omegaconf import DictConfig
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelSummary
-from pytorch_lightning.plugins.environments import TorchElasticEnvironment
 
-from nemo.collections.common.metrics.perf_metrics import FLOPsMeasurementCallback
-from nemo.collections.nlp.parts.nlp_overrides import (
-    CustomProgressBar,
-    FSDPMixedPrecisionPlugin,
-    GradScaler,
-    MegatronHalfPrecisionPlugin,
-    NLPDDPStrategy,
-    NLPDDPStrategyNotebook,
-    NLPFSDPStrategy,
-    PipelineMixedPrecisionPlugin,
-)
 from nemo.utils import logging
-from nemo.utils.callbacks.dist_ckpt_io import (
-    AsyncFinalizableCheckpointIO,
-    AsyncFinalizerCallback,
-    DistributedCheckpointIO,
+
+import nemo.collections.nlp.parts.megatron_trainer_builder
+
+from nemo.collections.nlp.parts.nlp_overrides import (
+    NLPFSDPStrategy,
+    GradScaler,
+    NLPDDPStrategyNotebook,
+    NLPDDPStrategy,
 )
 
+from flatflow.megatron.core.bpipe import bpipe_state
 
-class MegatronTrainerBuilder:
+class MegatronTrainerBuilder(nemo.collections.nlp.parts.megatron_trainer_builder.MegatronTrainerBuilder):
     """
     Builder type to hide complex configuration of PTL Trainers for Megatron LLM models.
     Can be extended to change behavior for a specific model.
     """
 
     def __init__(self, cfg: DictConfig) -> None:
-        self.cfg = cfg
+        super().__init__(cfg)
 
     def _training_strategy(self) -> Union[NLPDDPStrategy, NLPFSDPStrategy]:
         """
@@ -64,28 +56,13 @@ class MegatronTrainerBuilder:
                 find_unused_parameters=False,
             )
 
-        if self.cfg.model.get('fsdp', False):
-            assert (
-                not self.cfg.model.optim.get('name') == 'distributed_fused_adam'
-                and not self.cfg.model.optim.get('name') == 'mcore_distributed_optim'
-            ), 'Distributed optimizer cannot be used with FSDP.'
-            sharded_checkpoint = self.cfg.model.get('fsdp_sharded_checkpoint', False)
-            if self.cfg.model.get('tensor_model_parallel_size', 1) > 1:
-                assert not sharded_checkpoint, 'FSDP sharded checkpoint is not supported when TP size > 1.'
-            if self.cfg.model.get('megatron_amp_O2', False):
-                logging.info('Torch FSDP is not compatible with O2 precision recipe. Setting O2 `False`.')
-                self.cfg.model.megatron_amp_O2 = False
-            return NLPFSDPStrategy(
-                limit_all_gathers=self.cfg.model.get('fsdp_limit_all_gathers', True),
-                sharding_strategy=self.cfg.model.get('fsdp_sharding_strategy', 'full'),
-                cpu_offload=self.cfg.model.get('fsdp_cpu_offload', False),
-                grad_reduce_dtype=self.cfg.model.get('fsdp_grad_reduce_dtype', 32),
-                sharded_checkpoint=sharded_checkpoint,
-                precision=self.cfg.trainer.precision,
-                nccl_communicator_config_path=self.cfg.model.get('nccl_communicator_config_path', None),
-                sharp=self.cfg.model.get('sharp', False),
-                use_orig_params=self.cfg.model.get('fsdp_use_orig_params', False),
-            )
+        assert self.cfg.model.get('fsdp', False) == False, "FSDP is not supported in BPipe yet"
+
+        # Set BPIPE options before setting DDP strategy to ensure proper 
+        # pipeline parallel (PP) behavior. Override PP-related functions 
+        # to integrate BPIPE's memory-balanced execution.
+        use_bpipe = self.cfg.model.get('use_bpipe', False)
+        bpipe_state.set_bpipe_option(use_bpipe)
 
         return NLPDDPStrategy(
             no_ddp_communication_hook=True,
@@ -96,152 +73,7 @@ class MegatronTrainerBuilder:
             dist_ckpt_parallel_save=self.cfg.model.get('dist_ckpt_parallel_dist_opt', True),
         )
 
-    def _grad_scaler(self) -> GradScaler:
-        """
-        Returns a scaler for precision plugins.
-        """
-        return GradScaler(
-            init_scale=self.cfg.model.get('native_amp_init_scale', 2**32),
-            growth_interval=self.cfg.model.get('native_amp_growth_interval', 1000),
-            hysteresis=self.cfg.model.get('hysteresis', 2),
-        )
-
-    def _plugins(self) -> list:
-        """
-        Returns:
-            plugins: list of plugins passed to Trainer.plugins including precision plugins.
-        """
-        megatron_amp_O2 = self.cfg.model.get('megatron_amp_O2', False)
-        with_distributed_adam = (
-            (
-                self.cfg.model.optim.get('name') == 'distributed_fused_adam'
-                or self.cfg.model.optim.get('name') == 'mcore_distributed_optim'
-            )
-            if self.cfg.model.get('optim')
-            else False
-        )
-
-        plugins = []
-        if self.cfg.trainer.precision in [16, '16', 'bf16', '16-mixed', 'bf16-mixed']:
-            scaler = None
-            if self.cfg.trainer.precision in [16, '16', '16-mixed']:
-                if not self.cfg.model.get('fsdp', False):
-                    scaler = self._grad_scaler()
-                plugin_precision = '16-mixed'
-            else:
-                plugin_precision = 'bf16-mixed'
-
-            if megatron_amp_O2 and not with_distributed_adam:
-                plugins.append(MegatronHalfPrecisionPlugin(precision=plugin_precision, device='cuda', scaler=scaler))
-            else:
-                if self.cfg.model.get('fsdp', False):
-                    plugins.append(FSDPMixedPrecisionPlugin(precision=plugin_precision, scaler=scaler))
-                else:
-                    plugins.append(
-                        PipelineMixedPrecisionPlugin(precision=plugin_precision, device='cuda', scaler=scaler)
-                    )
-            self.cfg.trainer.precision = None
-
-        if self.cfg.get('cluster_type', None) == 'BCP':
-            plugins.append(TorchElasticEnvironment())
-
-        # Use dist-ckt for non-FSDP MCore models
-        use_dist_ckpt = not self.cfg.model.get('fsdp', False) and (
-            self.cfg.model.get('mcore_gpt', False) or self.cfg.model.get('mcore_bert', False)
-        )
-        async_save = self.cfg.get('exp_manager', {}).get('checkpoint_callback_params', {}).get('async_save', False)
-        if use_dist_ckpt:
-            checkpoint_io = DistributedCheckpointIO.from_config(self.cfg.model, async_save)
-            if async_save:
-                checkpoint_io = AsyncFinalizableCheckpointIO(checkpoint_io)
-            plugins.append(checkpoint_io)
-        elif async_save:
-            raise MisconfigurationException(
-                'exp_manager.checkpoint_callback_params.async_save=True without'
-                'distributed checkpoints is currently not supported'
-            )
-
-        return plugins
-
-    def _callbacks(self, callbacks: Optional[list]) -> list:
-        """
-        Returns:
-            callbacks: list of callbacks passed to Trainer.callbacks.
-        """
-        if callbacks is None:
-            callbacks = []
-        # enable_progress_bar is True by default. If cfg.trainer.enable_progress_bar=False, CustomProgressBar is not appended to callbacks
-        if 'enable_progress_bar' not in self.cfg.trainer or self.cfg.trainer.enable_progress_bar:
-            callbacks.append(CustomProgressBar())
-
-        if self.cfg.get('exp_manager', {}).get('checkpoint_callback_params', {}).get('async_save', False):
-            callbacks.append(AsyncFinalizerCallback())
-
-        if self.cfg.get('exp_manager', {}).get('log_tflops_per_sec_per_gpu', True):
-            callbacks.append(FLOPsMeasurementCallback(self.cfg))
-
-        return callbacks
-
-    def create_trainer(self, callbacks=None) -> Trainer:
-        # cfg.trainer.precision becomes None in Trainer if precision_plugins exist since both precision plugins and precision
-        precision = self.cfg.trainer.precision
-        strategy = self._training_strategy()
-        plugins = self._plugins()
-        callbacks = self._callbacks(callbacks)
-        trainer = Trainer(plugins=plugins, strategy=strategy, **self.cfg.trainer, callbacks=callbacks)
-        # Restore the precision value after Trainer is built.
-        self.cfg.trainer.precision = precision
-        return trainer
-
-
-class MegatronBertTrainerBuilder(MegatronTrainerBuilder):
-    """Builder for BERT model Trainer with overrides."""
-
-    def _grad_scaler(self) -> GradScaler:
-        return GradScaler(
-            init_scale=self.cfg.model.get('native_amp_init_scale', 2**32),
-            growth_interval=self.cfg.model.get('native_amp_growth_interval', 1000),
-        )
-
-
-class MegatronT5TrainerBuilder(MegatronTrainerBuilder):
-    """Builder for T5 model Trainer with overrides."""
-
-    def _callbacks(self, callbacks: Optional[list]) -> list:
-        callbacks = super()._callbacks(callbacks)
-        callbacks.append(ModelSummary(max_depth=3))
-        return callbacks
-
-    def create_trainer(self, callbacks=None) -> Trainer:
-        strategy = self._training_strategy()
-        plugins = self._plugins()
-        callbacks = self._callbacks(callbacks)
-        return Trainer(plugins=plugins, strategy=strategy, **self.cfg.trainer, callbacks=callbacks)
-
-
-class MegatronStableDiffusionTrainerBuilder(MegatronTrainerBuilder):
-    """Builder for SD model Trainer with overrides."""
-
-    def _training_strategy(self) -> NLPDDPStrategy:
-        """
-        Returns a ddp strategy passed to Trainer.strategy.
-        """
-        ddp_overlap = self.cfg.model.get("ddp_overlap", True)
-        if ddp_overlap:
-            return NLPDDPStrategy(
-                no_ddp_communication_hook=False,
-                gradient_as_bucket_view=self.cfg.model.gradient_as_bucket_view,
-                find_unused_parameters=True,
-                bucket_cap_mb=256,
-            )
-        else:
-            return NLPDDPStrategy(
-                no_ddp_communication_hook=True,
-                gradient_as_bucket_view=self.cfg.model.gradient_as_bucket_view,
-                find_unused_parameters=False,
-            )
-
-
+        
 class MegatronLMPPTrainerBuilder(MegatronTrainerBuilder):
     """Builder for scripts where grad scaler is turned off for pipeline parallel LM model. E.g. PEFT tuning scripts"""
 


### PR DESCRIPTION
# PR: Add `use_bpipe` Option

This PR introduces the `use_bpipe` option with the following updates and additions.

## ✅ Updates

### **Modified Files**
- **`flatflow/nemo/collections/nlp/parts/`**
  - **`megatron_trainer_builder.py`**
    - Import `bpipe_state.py`
    - Update the import path for `nlp_override.py`
- **`examples/nemo/nlp/language_modeling/tuning/`**
  - **`conf/megatron_gpt_finetuning_config.yaml`**
    - Add support for specifying the `use_bpipe` option
  - **`megatron_gpt_finetuning.py`**
    - Update the module path for `megatron_trainer_builder`

## 🆕 Additions

- **`flatflow/megatron/core/bpipe/`**
  - **`bpipe_state.py`**  
    - Configure the `bpipe` state
  - **`__init__.py`**

This PR sets up the foundation for integrating `bpipe` functionality into the existing pipeline.
