### PR TITLE
profiler: fix memory footprint profile

### DIFF
--- a/flatflow/megatron/core/pipeline_parallel/schedules.py
+++ b/flatflow/megatron/core/pipeline_parallel/schedules.py
@@ -8,6 +8,8 @@ from typing import Iterator, List, Union
 
 import nvtx
 import torch
+from torch.autograd.variable import Variable
+
 from megatron.core import parallel_state
 from megatron.core.enums import ModelType
 from megatron.core.pipeline_parallel import p2p_communication
@@ -19,7 +21,6 @@ from megatron.core.utils import (
     get_model_type,
     get_model_xattn,
 )
-from torch.autograd.variable import Variable
 
 import flatflow.torch.profiler
 

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -1089,7 +1089,13 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
                     )
 
             if self.enable_profile and not forward_only:
-                with flatflow.torch.profiler.MemoryProfiler.profile(tag=f"forward-{global_microbatch_id}"):
+                meta_info = {
+                    "global_bs": get_current_global_batch_size(),
+                    "micro_bs": get_micro_batch_size(),
+                    "tok_total": forward_args['input_ids'].size(1)
+                }
+
+                with flatflow.torch.profiler.MemoryProfiler.profile(tag=f"forward-{global_microbatch_id}", **meta_info):
                     nvtx_ctx = nvtx.annotate(message="forward", color="green", domain="forward", category=f"{global_microbatch_id}")
                     nvtx_ctx.__enter__()
                     try:

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -1079,15 +1079,15 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
             if self.enable_profile and not forward_only:
                 # Build runtime batch metadata; for concat-based dataset the logical
                 # micro-batch size equals the number of sample_ids concatenated.
-                if 'sample_ids' in batch and isinstance(batch['sample_ids'], (list, tuple)):
-                    micro_bs_logic = len(batch['sample_ids'])  # logical micro-batch size
+                if "sample_ids" in batch and isinstance(batch["sample_ids"], (list, tuple)):
+                    micro_bs_logic = len(batch["sample_ids"])  # logical micro-batch size
                 else:
-                    micro_bs_logic = forward_args['input_ids'].size(0)
+                    micro_bs_logic = forward_args["input_ids"].size(0)
 
                 meta_info = {
                     "micro_bs": micro_bs_logic,
                     "global_bs": micro_bs_logic * parallel_state.get_data_parallel_world_size(),
-                    "tok_total": forward_args['input_ids'].numel(),
+                    "tok_total": forward_args["input_ids"].numel(),
                 }
 
                 with flatflow.torch.profiler.MemoryProfiler.profile(tag=f"forward-{global_microbatch_id}", **meta_info):

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -26,30 +26,18 @@ from nemo.collections.common.metrics import MetricStringToTorchMetric
 from nemo.collections.nlp.data.language_modeling.megatron.base_dataset_utils import (
     get_datasets_weights_and_num_samples,
 )
-from nemo.collections.nlp.data.language_modeling.megatron.blendable_dataset import (
-    BlendableDataset,
-)
-from nemo.collections.nlp.data.language_modeling.megatron.gpt_sft_chat_dataset import (
-    GPTSFTChatDataset,
-)
-from nemo.collections.nlp.data.language_modeling.megatron.gpt_sft_dataset import (
-    GPTSFTDataset,
-    GPTSFTPackedDataset,
-)
+from nemo.collections.nlp.data.language_modeling.megatron.blendable_dataset import BlendableDataset
+from nemo.collections.nlp.data.language_modeling.megatron.gpt_sft_chat_dataset import GPTSFTChatDataset
+from nemo.collections.nlp.data.language_modeling.megatron.gpt_sft_dataset import GPTSFTDataset, GPTSFTPackedDataset
 from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers import (
     MegatronPretrainingBatchSampler,
 )
-from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import (
-    MegatronGPTModel,
-)
+from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
 from nemo.collections.nlp.modules.common.megatron.utils import (
     average_losses_across_data_parallel_group,
     get_iterator_k_split,
 )
-from nemo.collections.nlp.modules.common.text_generation_utils import (
-    generate,
-    get_computeprob_response,
-)
+from nemo.collections.nlp.modules.common.text_generation_utils import generate, get_computeprob_response
 from nemo.collections.nlp.parts.mixins.nlp_adapter_mixins import NLPAdapterModelMixin
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.utils import AppState, logging

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -232,7 +232,6 @@ class ComputeProfiler:
 
 
 class MemoryProfiler:
-
     @staticmethod
     def _get_output_filename() -> str:
         dp_rank = parallel_state.get_data_parallel_rank()

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -234,17 +234,16 @@ class ComputeProfiler:
 class MemoryProfiler:
 
     @staticmethod
-    def _get_output_filename(self) -> str:
+    def _get_output_filename() -> str:
         dp_rank = parallel_state.get_data_parallel_rank()
         pp_rank = parallel_state.get_pipeline_model_parallel_rank()
         tp_rank = parallel_state.get_tensor_model_parallel_rank()
         rank = os.environ.get("LOCAL_RANK", "0")
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        return f"memory_profile_rank{rank}_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}_{timestamp}.jsonl"
+        return f"memory_profile_rank{rank}_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}.jsonl"
     
     @staticmethod
     @contextlib.contextmanager
-    def profile(self, tag: str = ""):
+    def profile(tag: str = ""):
         if not torch.cuda.is_available():
             yield
             return
@@ -271,16 +270,16 @@ class MemoryProfiler:
                 "world_size": int(os.environ.get("WORLD_SIZE", 1))
             }
 
-            self.save_log(tag, new_data)
+            MemoryProfiler.save_log(tag, new_data, MemoryProfiler._get_output_filename())
 
     @staticmethod
-    def save_log(self, tag: str, new_data: Dict[str, Any]):
+    def save_log(tag: str, new_data: Dict[str, Any], output_file: str):
         try:
-            os.makedirs(os.path.dirname(self.output_file) if os.path.dirname(self.output_file) else ".", exist_ok=True)
+            os.makedirs(os.path.dirname(output_file) if os.path.dirname(output_file) else ".", exist_ok=True)
 
             record = {"tag": tag, **new_data}
-            with open(self.output_file, 'a') as f:
+            with open(output_file, 'a') as f:
                 f.write(json.dumps(record) + '\n')
 
         except Exception as e:
-            print(f"Warning: Failed to save memory profile to {self.output_file}: {e}")
+            print(f"Warning: Failed to save memory profile to {output_file}: {e}")

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -243,7 +243,7 @@ class MemoryProfiler:
     
     @staticmethod
     @contextlib.contextmanager
-    def profile(tag: str = ""):
+    def profile(tag: str = "", **metadata):
         if not torch.cuda.is_available():
             yield
             return
@@ -267,8 +267,13 @@ class MemoryProfiler:
                 "reserved_mb": reserved_diff,
                 "timestamp": datetime.datetime.now().isoformat(),
                 "rank": int(os.environ.get("LOCAL_RANK", 0)),
-                "world_size": int(os.environ.get("WORLD_SIZE", 1))
+                "world_size": int(os.environ.get("WORLD_SIZE", 1)),
             }
+
+            if metadata:
+                for k, v in metadata.items():
+                    if k not in new_data:
+                        new_data[k] = v
 
             MemoryProfiler.save_log(tag, new_data, MemoryProfiler._get_output_filename())
 

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -232,10 +232,8 @@ class ComputeProfiler:
 
 
 class MemoryProfiler:
-    def __init__(self, enabled: bool = True):
-        self.enabled = enabled
-        self.output_file = self._get_output_filename()
 
+    @staticmethod
     def _get_output_filename(self) -> str:
         dp_rank = parallel_state.get_data_parallel_rank()
         pp_rank = parallel_state.get_pipeline_model_parallel_rank()
@@ -243,10 +241,11 @@ class MemoryProfiler:
         rank = os.environ.get("LOCAL_RANK", "0")
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         return f"memory_profile_rank{rank}_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}_{timestamp}.jsonl"
-
+    
+    @staticmethod
     @contextlib.contextmanager
     def profile(self, tag: str = ""):
-        if not self.enabled or not torch.cuda.is_available():
+        if not torch.cuda.is_available():
             yield
             return
 
@@ -274,6 +273,7 @@ class MemoryProfiler:
 
             self.save_log(tag, new_data)
 
+    @staticmethod
     def save_log(self, tag: str, new_data: Dict[str, Any]):
         try:
             os.makedirs(os.path.dirname(self.output_file) if os.path.dirname(self.output_file) else ".", exist_ok=True)


### PR DESCRIPTION
This PR includes fixed logic of memory profiling.

1. `torch/profiler/profiler`
     - use profiler by context manager
     - change it to static method  and save memory profile metadata to each gpu rank
2. `megatron/core/pipeline_parallel/schedules`
     - Track memory allocated data for each microbatch id at backward
3. `nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model`
     - add calculated total token for each batch as metadata
     - add micro batch, global batch info as metadata
     - Track memory allocated data for each microbatch id at forward
     
By this PR we can visualize and make metrics for experiment.