### PR TITLE
profiler: enable partial step profile

### DIFF
--- a/examples/nemo/nlp/language_modeling/tuning/conf/megatron_gpt_finetuning_config.yaml
+++ b/examples/nemo/nlp/language_modeling/tuning/conf/megatron_gpt_finetuning_config.yaml
@@ -88,7 +88,8 @@ model:
   use_flatflow: False
   enable_profile: True
   use_bpipe: False
-  
+  batch_p2p_comm: False
+
   peft:
     peft_scheme: "adapter"  # can be either "adapter", "ia3", or "ptuning"
     restore_from_path: null

--- a/flatflow/megatron/core/pipeline_parallel/schedules.py
+++ b/flatflow/megatron/core/pipeline_parallel/schedules.py
@@ -371,6 +371,7 @@ def backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, c
         output_tensor[0] = config.grad_scale_func(output_tensor[0])
 
     if enable_profile and not forward_only:
+        flatflow.torch.profiler.MemoryProfiler.set_step(global_microbatch_id)
         with flatflow.torch.profiler.MemoryProfiler.profile(tag=f"backward-{global_microbatch_id}"):
             nvtx_ctx = nvtx.annotate(message="backward", color="blue", domain="backward", category=f"{global_microbatch_id}")
             nvtx_ctx.__enter__()

--- a/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -120,7 +120,7 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
             # communicates through the IPv6 loopback interface only.
             channel = grpc.insecure_channel(f"[::1]:{port}")
             self.client = ControlPlaneClient(channel)
-            sizes = [sys.getsizeof(self.dataset, index) for index in (self.indices)]
+            sizes = [sys.getsizeof(self.dataset, index) for index in self.indices]
             self.client.Init(
                 data_parallel_rank,
                 data_parallel_size,

--- a/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/flatflow/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -98,9 +98,9 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
 
         indices = list(range(len(self.dataset)))
         remainder = len(indices) % self.data_parallel_size
-        if remainder != 0:
-            num_pad = self.data_parallel_size - remainder
-            self.indices = indices + indices[:num_pad]
+        if remainder != 0: # truncate the dataset to make it evenly divisible across the number of replicas
+            truncate_size = len(indices) - remainder
+            self.indices = list(range(truncate_size))
         else:
             self.indices = indices
 
@@ -120,7 +120,7 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
             # communicates through the IPv6 loopback interface only.
             channel = grpc.insecure_channel(f"[::1]:{port}")
             self.client = ControlPlaneClient(channel)
-            sizes = [sys.getsizeof(self.dataset, index) if index >=0 else 0 for index in range(self.indices)]
+            sizes = [sys.getsizeof(self.dataset, index) for index in (self.indices)]
             self.client.Init(
                 data_parallel_rank,
                 data_parallel_size,
@@ -146,7 +146,7 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
 
         # receive the reordered computation schedule from the control plane
         if is_model_parallel_src:
-            self.schedule = self.client.Scatter(self.epoch, list(range(len(self.dataset))))
+            self.schedule = self.client.Scatter(self.epoch, self.indices)
             self.schedule_size = [len(self.schedule)]
             self.epoch += 1
         else:

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -119,9 +119,9 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
         self.enable_profile = cfg.get("enable_profile", True)
         if self.enable_profile:
             flatflow.torch.profiler.MemoryProfiler.configure(
-                start_step=cfg.get('memory_profile_start_step', 0),
-                end_step=cfg.get('memory_profile_end_step', None),
-                step_interval=cfg.get('memory_profile_interval', 1),
+                start_step=cfg.get("memory_profile_start_step", 0),
+                end_step=cfg.get("memory_profile_end_step", None),
+                step_interval=cfg.get("memory_profile_interval", 1),
                 enabled=True
             )
         if self.use_flatflow:
@@ -397,13 +397,13 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
         if self.use_flatflow:
             num_microbatches = get_num_microbatches()
             logical_global_step = self.trainer.global_step * num_microbatches
-            micro_batch_size = self.cfg.get ('micro_batch_size', 1)
+            micro_batch_size = self.cfg.get ("micro_batch_size", 1)
             data_parallel_size = self.trainer.world_size // (
-                self.cfg.get ('tensor_model_parallel_size', 1) * self.cfg.get ('pipeline_model_parallel_size', 1)
+                self.cfg.get ("tensor_model_parallel_size", 1) * self.cfg.get ("pipeline_model_parallel_size", 1)
             )
             logical_consumed_samples = logical_global_step * micro_batch_size * num_microbatches * data_parallel_size
-            self.log('global_step', logical_global_step, prog_bar=True, rank_zero_only=True, batch_size=1) 
-            self.log('consumed_samples', logical_consumed_samples, prog_bar=True, rank_zero_only=True, batch_size=1)
+            self.log("global_step", logical_global_step, prog_bar=True, rank_zero_only=True, batch_size=1) 
+            self.log("consumed_samples", logical_consumed_samples, prog_bar=True, rank_zero_only=True, batch_size=1)
         return result
 
     def fwd_bwd_step(self, dataloader_iter, forward_only, first_val_step=None):

--- a/flatflow/torch/profiler/profiler.py
+++ b/flatflow/torch/profiler/profiler.py
@@ -246,7 +246,7 @@ class MemoryProfiler:
         cls._step_interval = step_interval
         cls._enabled = enabled
         
-        # 환경변수로도 설정 가능
+        # Allow configuration via environment variables
         if os.environ.get("MEMORY_PROFILE_START_STEP"):
             cls._profile_start_step = int(os.environ.get("MEMORY_PROFILE_START_STEP"))
         if os.environ.get("MEMORY_PROFILE_END_STEP"):
@@ -260,7 +260,7 @@ class MemoryProfiler:
               f"end_step={cls._profile_end_step}, interval={cls._step_interval}, enabled={cls._enabled}")
     
     @classmethod
-    def set_step(cls, step: int):
+    def set_step(cls, step):
         cls._current_step = int(step) if isinstance(step, str) else step
     
     @classmethod
@@ -353,7 +353,7 @@ class MemoryProfiler:
         except (OSError, IOError) as io_err:
             print(f"Warning: File I/O error when saving to {output_file}: {io_err}")
         except Exception as e:
-            print(f"Warning: Unexpected error saving memory profile to {output_file}: {e}")
+            print(f"Warning: Failed to save memory profile to {output_file}: {e}")
 
     @staticmethod
     def _serialize(obj):
@@ -366,14 +366,14 @@ class MemoryProfiler:
             return [MemoryProfiler._serialize(item) for item in obj]
         elif isinstance(obj, dict):
             return {k: MemoryProfiler._serialize(v) for k, v in obj.items()}
-        elif hasattr(obj, 'item') and callable(getattr(obj, 'item')) and not isinstance(obj, torch.Tensor):
+        elif hasattr(obj, "item") and callable(getattr(obj, "item")) and not isinstance(obj, torch.Tensor):
             try:
                 return obj.item()
             except (ValueError, TypeError):
                 return str(obj)
         elif isinstance(obj, (int, float, str, bool, type(None))):
             return obj
-        elif hasattr(obj, 'tolist') and callable(getattr(obj, 'tolist')):
+        elif hasattr(obj, "tolist") and callable(getattr(obj, "tolist")):
             try:
                 return obj.tolist()
             except (ValueError, TypeError):


### PR DESCRIPTION
This PR includes several updates for profiling memory and other minor updates

Fixing memory profiling 
- `profiler.py`
  - enable to partial step profiling to efficiently run experiment (too frequent cuda.synchronize was a problem)
  - fix tensor serialization for saving at log file 
- `megatron_gpt_sft_model.py`
  - change `Memoryprofiler` instance usage (setting up configuration for logging memory step by step) 
- `schedules.py`
  - add setting up batch id for memory profiler

Minor updates 
- `megatron_gpt_sft_model.py`
  - fix `consumed_samples`, `global_step` logging in tqdm 
- `megatron_gpt_finetuning_config.yaml`
  - add `batch_p2p_comm` default as False
- `megatron_batch_sampler.py`
  - add if case if dataset sample size is not divisible by data parallel size
