### PR TITLE
language_modeling: fix microbatch processing 

### DIFF
--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -1213,11 +1213,11 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
                         elif key == 'cu_seqlens':
                             sub_cu_seqlens = cu_seqlens_numpy[start_seq_idx : end_seq_idx + 2]
                             relative_cu_seqlens = sub_cu_seqlens - cu_seqlens_numpy[start_seq_idx]
-                            # Add sentinel back
+
                             final_cu_seqlens = np.append(relative_cu_seqlens, [-1])
-                            microbatch_dict[key] = torch.from_numpy(final_cu_seqlens).to(device=tensor.device).unsqueeze(0)
+                            microbatch_dict[key] = torch.from_numpy(final_cu_seqlens).to(device=tensor.device, dtype=torch.int32).unsqueeze(0)
                         elif key == 'attention_mask':
-                            # This tensor is a placeholder, just copy it.
+                            # This tensor is a placeholder, copy.
                             microbatch_dict[key] = tensor
                         elif key == 'max_seqlen':
                             microbatch_dict[key] = torch.from_numpy(final_cu_seqlens).to(device=tensor.device, dtype=torch.int32).unsqueeze(0)

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -81,6 +81,100 @@ except (ImportError, ModuleNotFoundError):
 
 __all__ = ['MegatronGPTSFTModel']
 
+from typing import Dict, Iterator, List, Optional, Tuple, Union
+import numpy as np
+def flatflow_get_iterator_k_split(batch: Union[Dict, List[torch.Tensor]], num_microbatches: int, enforce_divisible_batch: Optional[bool] = True):
+    if isinstance(batch, dict):
+        discard_items = [k for k, v in batch.items() if not isinstance(v, (torch.Tensor, list))]
+        if len(discard_items) > 0:
+            print(f"Warning: {discard_items} are not tensors or lists, they will be discarded")
+
+        batch = {k: v for k, v in batch.items() if isinstance(v, (torch.Tensor, list))}
+        tensor_items = {k: v for k, v in batch.items() if isinstance(v, torch.Tensor)}
+        list_items = {k: v for k, v in batch.items() if isinstance(v, list)}
+
+        # --- Start of new logic for cu_seqlens ---
+        if 'cu_seqlens' in tensor_items:
+            
+            # example total microbatch 4, split into 2 microbatches
+            microbatches = []
+            
+            cu_seqlens_tensor = tensor_items['cu_seqlens']
+            # The last element in cu_seqlens is a sentinel -1 from the dataset code
+            cu_seqlens_numpy = cu_seqlens_tensor.squeeze(0).cpu().numpy()[:-1]
+            # example
+            # cu_seqlens_tensor = tensor([[ 0, 10, 15, 23, 30, -1]])
+            # L#125: cu_seqlens_numpy = [ 0, 10, 15, 23, 30]
+            num_sequences = len(cu_seqlens_numpy) - 1
+            # num_sequences = 5
+            if enforce_divisible_batch and num_sequences % num_microbatches != 0:
+                raise ValueError(f"Batch size ({num_sequences}) is not evenly divisible by num_microbatches ({num_microbatches})")
+
+            microbatch_seq_indices_list = np.array_split(range(num_sequences), num_microbatches)
+            # microbatch_seq_indices_list = [[0,1], [2,3]]
+            tensor_keys = list(tensor_items.keys())
+            list_keys = list(list_items.keys())
+
+            for i in range(num_microbatches):
+                microbatch_dict = {}
+                seq_indices = microbatch_seq_indices_list[i]
+
+                if len(seq_indices) == 0:
+                    # Handle empty microbatches if num_sequences < num_microbatches
+                    for key in tensor_keys:
+                        microbatch_dict[key] = torch.tensor([])
+                    for key in list_keys:
+                        microbatch_dict[key] = []
+                    microbatches.append(microbatch_dict)
+                    continue
+
+                start_seq_idx = seq_indices[0]
+                end_seq_idx = seq_indices[-1]
+                start_token_idx = cu_seqlens_numpy[start_seq_idx]
+                end_token_idx = cu_seqlens_numpy[end_seq_idx + 1]
+                seqlens_numpy = np.diff(cu_seqlens_numpy)
+                
+                # Handle Tensors
+                for key, tensor in tensor_items.items():
+                    tensor_squeezed = tensor.squeeze(0)
+                    if key in ['tokens', 'labels', 'loss_mask', 'position_ids']:
+                        microbatch_dict[key] = tensor_squeezed[start_token_idx:end_token_idx].unsqueeze(0)
+                    elif key == 'cu_seqlens':
+                        sub_cu_seqlens = cu_seqlens_numpy[start_seq_idx : end_seq_idx + 2]
+                        relative_cu_seqlens = sub_cu_seqlens - cu_seqlens_numpy[start_seq_idx]
+                        # Add sentinel back
+                        final_cu_seqlens = np.append(relative_cu_seqlens, [-1])
+                        microbatch_dict[key] = torch.from_numpy(final_cu_seqlens).to(device=tensor.device).unsqueeze(0)
+                    elif key == 'attention_mask':
+                        # This tensor is a placeholder, just copy it.
+                        microbatch_dict[key] = tensor
+                    elif key == 'max_seqlen':
+                        # Recalculate max_seqlen for the microbatch
+                        micro_seqlens = seqlens_numpy[seq_indices]
+                        microbatch_dict[key] = torch.from_numpy(final_cu_seqlens).to(device=tensor.device, dtype=torch.int32).unsqueeze(0)
+                    elif key == 'cu_seqlens_argmin':
+                        # Recalculate argmin for the new cu_seqlens of the microbatch
+                        # This depends on the 'cu_seqlens' key being processed first if we reuse the value.
+                        # For safety, we recalculate it here.
+                        sub_cu_seqlens = cu_seqlens_numpy[start_seq_idx : end_seq_idx + 2]
+                        relative_cu_seqlens = sub_cu_seqlens - cu_seqlens_numpy[start_seq_idx]
+                        final_cu_seqlens_numpy = np.append(relative_cu_seqlens, [-1])
+                        microbatch_dict[key] = torch.tensor([[np.argmin(final_cu_seqlens_numpy)]], device=tensor.device, dtype=tensor.dtype)
+                    else:
+                        raise RuntimeError(f"Unhandled tensor '{key}' in flatflow_get_iterator_k_split. Please add specific logic for it.")
+
+                # Handle Lists
+                for key, val_list in list_items.items():
+                    if key == 'token_count':
+                        # Recalculate token_count for the microbatch
+                        microbatch_dict[key] = [end_token_idx - start_token_idx]
+                    else:
+                        # For other lists, split them based on sequence counts
+                        item_splits = np.array_split(val_list, num_sequences)
+                        microbatch_dict[key] = [item for j in seq_indices for item in item_splits[j]]
+
+                microbatches.append(microbatch_dict)
+    return itertools.chain(microbatches)
 
 class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
     """
@@ -392,58 +486,25 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
         else:
             return base_key + f"dataloader{dataloader_idx}"
 
-    def training_step(self, dataloader_iter):
-        result = super() .training_step(dataloader_iter)
-        if self.use_flatflow:
-            num_microbatches = get_num_microbatches()
-            logical_global_step = self.trainer.global_step * num_microbatches
-            micro_batch_size = self.cfg.get ("micro_batch_size", 1)
-            data_parallel_size = self.trainer.world_size // (
-                self.cfg.get ("tensor_model_parallel_size", 1) * self.cfg.get ("pipeline_model_parallel_size", 1)
-            )
-            logical_consumed_samples = logical_global_step * micro_batch_size * num_microbatches * data_parallel_size
-            self.log("global_step", logical_global_step, prog_bar=True, rank_zero_only=True, batch_size=1) 
-            self.log("consumed_samples", logical_consumed_samples, prog_bar=True, rank_zero_only=True, batch_size=1)
-        return result
-
     def fwd_bwd_step(self, dataloader_iter, forward_only, first_val_step=None):
         # Return only batch if batch, batch_idx, dataloder_idx are extracted as a tuple in the previous func
         # call like validation_step otherwise return tuple
         # (in which case dataloader_iter is still a PTL _DataFetcherWrapper object)
         num_microbatches = get_num_microbatches()
-        if not self.use_flatflow:
-            micro_batch_size = get_micro_batch_size()
-            if isinstance(dataloader_iter, _DataFetcherWrapper):
-                batch, _, _ = next(dataloader_iter)
-            else:
-                batch = next(dataloader_iter)
-
-            log_token_counts = self.cfg.get('log_token_counts', False)
-            if log_token_counts:
-                token_count_avg = sum(batch['token_count']) / len(batch['token_count'])
-
-            # Pass only torch.Tensor to prevent errors when process get_iterator_k_split()
-            batch = {k: v for k, v in batch.items() if isinstance(v, torch.Tensor)}
-            _, seq_length = batch['tokens'].shape
-            data_iter = get_iterator_k_split(batch, num_microbatches)
+        micro_batch_size = get_micro_batch_size()
+        if isinstance(dataloader_iter, _DataFetcherWrapper):
+            batch, _, _ = next(dataloader_iter)
         else:
-            # Using flatflow, the 'stack-dim' batch size is always 1 for a microbatch. Instead, the `get_micro_batch_size()`
-            # corresponds to the 'concat-dim' batch size of microbatches, processed in `flatflow...GPTSFTDataset`.
-            micro_batch_size = 1
-            batch = []
-            iter_count = num_microbatches
-            while len(batch) < iter_count:
-                if isinstance(dataloader_iter, _DataFetcherWrapper):
-                    microbatch, _, _ = next(dataloader_iter)
-                else:
-                    microbatch = next(dataloader_iter)
-                batch.append(microbatch)
-            log_token_counts = self.cfg.get('log_token_counts', False)
-            if log_token_counts:
-                token_count_avg = sum([mb['token_count'] for mb in batch]) / (len(batch) * get_micro_batch_size())
-            # seq_length is required but will be ignored. See megatron...schedules.get_forward_backword_func's comment(docstring).
-            seq_length = sum([mb['tokens'].shape[1] for mb in batch])
-            data_iter = itertools.chain(batch)
+            batch = next(dataloader_iter)
+
+        log_token_counts = self.cfg.get('log_token_counts', False)
+        if log_token_counts:
+            token_count_avg = sum(batch['token_count']) / len(batch['token_count'])
+
+        # Pass only torch.Tensor to prevent errors when process get_iterator_k_split()
+        batch = {k: v for k, v in batch.items() if isinstance(v, torch.Tensor)}
+        _, seq_length = batch['tokens'].shape
+        data_iter = get_iterator_k_split(batch, num_microbatches) if not self.use_flatflow else flatflow_get_iterator_k_split(batch, num_microbatches)
 
         if log_token_counts:
             self.log('seq_length_padded', seq_length, prog_bar=True, batch_size=1)


### PR DESCRIPTION
This PR includes the logic of microbatch processing followed by forward & backward step for pipeline parallelism.

For pipeline parallelism in NeMo, we need to prepare `microbatches` by splitting `batch` by calling `get_iterator_k_split()`.
As FlatFlow also yields the same amount of data samples as global batch size, we need to split concatenated batch in to multiple `mircobatches`.

1. Overwriting logging in `training_step` function is unnecessary, since we figured out that this PR solves the previous logging error.
2. Inside `fwd_bwd_step`, details are explained as below.

    > Either using FlatFlow or not doesn't effect the size of `next(dataloader_iter)` result.
    > Eventually we don't need `if else` statement for a `next(dataloader_iter)` situation.
    >  If we don't use FlatFlow, NeMo splits batch in a stack manner.
    > We just need to use different splitting method since FlatFlow is adhering concatenated manner. 
- We added `get_iterator_k_split` as Instance Method to handle concatenated batch. 

fyi. After figuring out whether this method can be also used in pretraining task, this is going to be refactored.
Below is the verified result of this PR.

```bash

Dataset: alpaca
global batch size: 8
micro batch size: 2
num gpus: 4

flatflow false : 3:52
    
`Trainer.fit` stopped: `max_steps=937` reached.
Epoch 0: : 100%|███████████████████████████████████████████████████████| 937/937 [03:52<00:00, reduced_train_loss=2.340, global_step=936.0, consumed_samples=7496.0, train_step_timing in s=0.177]
[NeMo E 2025-07-23 07:00:56 perf_metrics:84] Failed to calculate TFLOPs per sec per GPU.
    FLOPs measurement not supported for finetuning jobs
[NeMo I 2025-07-23 07:00:56 perf_metrics:86] TFLOPs per sec per GPU=-1.00
[NeMo W 2025-07-23 07:00:58 nemo_logging:349] /usr/lib/python3.10/tempfile.py:999: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpabvq2brz'>
      _warnings.warn(warn_message, ResourceWarning)

flatflow true : 3:19

`Trainer.fit` stopped: `max_steps=937` reached.
Epoch 0: : 100%|████████████████████████████████████████████████████████| 937/937 [03:19<00:00, reduced_train_loss=2.260, global_step=3744.0, consumed_samples=3e+4, train_step_timing in s=0.189]
[NeMo E 2025-07-23 07:09:23 perf_metrics:84] Failed to calculate TFLOPs per sec per GPU.
    FLOPs measurement not supported for finetuning jobs
[NeMo I 2025-07-23 07:09:23 perf_metrics:86] TFLOPs per sec per GPU=-1.00
[NeMo W 2025-07-23 07:09:26 nemo_logging:349] /usr/lib/python3.10/tempfile.py:999: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpprbuctg5'>
      _warnings.warn(warn_message, ResourceWarning)
    
I0723 07:09:26.575374   52379 distributed.h:178] Finalize called from ipv6:%5B::1%5D:62046 (rank 0)
```