### PR TITLE
experiment: fix minor bugs

### DIFF
--- a/examples/nemo/nlp/language_modeling/conf/llama3_1_8b.yaml
+++ b/examples/nemo/nlp/language_modeling/conf/llama3_1_8b.yaml
@@ -1,3 +1,5 @@
+run:
+  name: llama3
 trainer:
   num_nodes: 16
   devices: 8
@@ -42,6 +44,7 @@ exp_manager:
 model:
   use_flatflow: false
   use_profile: false
+  model_path: null
   mcore_gpt: true
   micro_batch_size: 1
   global_batch_size: 2048

--- a/experiments/step1_training/run_train_multi_nodes_2409.sh
+++ b/experiments/step1_training/run_train_multi_nodes_2409.sh
@@ -40,6 +40,7 @@ torchrun --nproc-per-node 8 --nnodes ${NNODES} --node-rank ${RANK} \
        trainer.sft.val_check_interval=-1 \
        trainer.sft.save_interval=10000000 \
        model.megatron_amp_O2=True \
+       model.model_path=${NEMO_MODEL} \
        model.restore_from_path=${NEMO_MODEL} \
        model.answer_only_loss=True \
        model.tensor_model_parallel_size=${TP_SIZE} \

--- a/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/flatflow/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -458,7 +458,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         self.use_obfd = cfg.data.get("use_obfd", False)
 
         # Model path for export functionality (if available)
-        self.model_path = cfg.get("restore_from_path", None)
+        self.model_path = cfg.get("model_path", None)
         if self.model_path and self.model_path.endswith("/model.nemo"):
             self.model_path = self.model_path.split("/model.nemo")[0]
 


### PR DESCRIPTION
This PR includes several updates for pretraining task.
- Add `name` key,value for conf/ yaml file. 
   - Inorder to enable to calculate flops, name attribute is required so we need to add this.
   - Note:  Finetuning is not explicitly supported calculating FLOPS [reference](https://github.com/NVIDIA-NeMo/NeMo/blob/v2.0.0/nemo/collections/common/metrics/perf_metrics.py#L78). So we need to verify if we can modify code.
- Use `model_path` for `_export`
   - `restore_from_path` can be null and this variable is used for different purpose so we need to use different variable for `_export` function.
- fix `_export`
- Call import inside for later import to avoid circular import dependency.